### PR TITLE
fixing the poloniex and bittrex factory links

### DIFF
--- a/src/factories/index.ts
+++ b/src/factories/index.ts
@@ -46,12 +46,12 @@ export  { Bitfinex };
  * Poloniex factories
  */
 
-import * as Poloniex from './bitfinexFactories';
+import * as Poloniex from './poloniexFactories';
 export  { Poloniex };
 
 /**
  * Bittrex factories
  */
 
-import * as Bittrex from './bitfinexFactories';
+import * as Bittrex from './bittrexFactories';
 export  { Bittrex };


### PR DESCRIPTION
All links were pointing to bitfinex's factory. Now they point to appropriate factories.

fixes - https://github.com/coinbase/gdax-tt/issues/15