### PR TITLE
Add basic CCXT support for 70+ exchanges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GDAX Trading toolkit
 Provide all the tools traders need, both professional and hobbyist alike, to create automated trading bots on the
-GDAX and supported digital asset exchanges. Note: Node 6.11 is required.
+GDAX and supported digital asset exchanges. Note: Node 7.6 or above is required.
 
 
 ## Install

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/ws": "0.0.37",
     "bignumber.js": "4.0.2",
     "bintrees": "1.0.1",
+    "ccxt": "^1.6.72",
     "commander": "2.9.0",
     "crypto": "0.0.3",
     "gdax": "0.3.1",

--- a/src/exchanges/PublicExchangeAPI.ts
+++ b/src/exchanges/PublicExchangeAPI.ts
@@ -73,9 +73,13 @@ export interface Ticker {
 
 export interface Product {
     id: string;
+    // The id on the underlying source exchange
+    sourceId: string;
     baseCurrency: string;
     quoteCurrency: string;
     baseMinSize: BigJS;
     baseMaxSize: BigJS;
     quoteIncrement: BigJS;
+    // The original data from the underlying exchange
+    sourceData: any;
 }

--- a/src/exchanges/bitfinex/BitfinexExchangeAPI.ts
+++ b/src/exchanges/bitfinex/BitfinexExchangeAPI.ts
@@ -118,11 +118,13 @@ export class BitfinexExchangeAPI implements PublicExchangeAPI, AuthenticatedExch
                     const quote = prod.pair.slice(3, 6);
                     return {
                         id: REVERSE_PRODUCT_MAP[prod.pair] || prod.pair,
+                        sourceId: prod.pair,
                         baseCurrency: REVERSE_CURRENCY_MAP[base] || base,
                         quoteCurrency: REVERSE_CURRENCY_MAP[quote] || quote,
                         baseMinSize: Big(prod.minimum_order_size),
                         baseMaxSize: Big(prod.maximum_order_size),
-                        quoteIncrement: Big(prod.minimum_order_size)
+                        quoteIncrement: Big(prod.minimum_order_size),
+                        sourceData: prod
                     };
                 });
                 return products;

--- a/src/exchanges/bittrex/BittrexAPI.ts
+++ b/src/exchanges/bittrex/BittrexAPI.ts
@@ -55,11 +55,13 @@ export class BittrexAPI implements PublicExchangeAPI, AuthenticatedExchangeAPI {
                 const result: Product[] = data.result.map((market: any) => {
                     return {
                         id: market.MarketName, // same format as GDAX, so no need to map
+                        sourceId: market.MarketName,
                         baseCurrency: market.BaseCurrency,
                         quoteCurrency: market.marketCurrency,
                         baseMinSize: Big(market.MinTradeSize),
                         baseMaxSize: Big('1e18'),
-                        quoteIncrement: Big(market.MinTradeSize)
+                        quoteIncrement: Big(market.MinTradeSize),
+                        sourceData: market
                     };
                 });
                 return resolve(result);

--- a/src/exchanges/ccxt/index.ts
+++ b/src/exchanges/ccxt/index.ts
@@ -1,0 +1,262 @@
+/**********************************************************************************************************************
+ * @license                                                                                                           *
+ * Copyright 2017 Coinbase, Inc.                                                                                      *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License. You may obtain a copy of the License at                                                          *
+ *                                                                                                                    *
+ * http://www.apache.org/licenses/LICENSE-2.0                                                                         *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on*
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the                 *
+ * License for the specific language governing permissions and limitations under the License.                         *
+ **********************************************************************************************************************/
+
+import * as ccxt from 'ccxt';
+import { CCXTMarket } from 'ccxt';
+import { Product, PublicExchangeAPI, Ticker } from '../PublicExchangeAPI';
+import { AuthenticatedExchangeAPI, Balances } from '../AuthenticatedExchangeAPI';
+import { CryptoAddress, ExchangeTransferAPI, TransferRequest, TransferResult, WithdrawalRequest } from '../ExchangeTransferAPI';
+import { ExchangeAuthConfig } from '../AuthConfig';
+import { Big, BigJS } from '../../lib/types';
+import { BookBuilder } from '../../lib/BookBuilder';
+import { PlaceOrderMessage } from '../../core/Messages';
+import { LiveOrder } from '../../lib/Orderbook';
+import { Logger } from '../../utils/Logger';
+
+type ExchangeDefinition = [string, (opts: any) => ccxt.Exchange];
+// Supported exchanges, minus those with native support
+const exchanges: { [index: string]: ExchangeDefinition } = {
+    _1broker: ['1 Broker', ccxt._1broker],
+    _1btcxe: ['BTC XE', ccxt._1btcxe],
+    anxpro: ['ANX Pro', ccxt.anxpro],
+    binance: ['Binance', ccxt.binance],
+    bit2c: ['Bit2c', ccxt.bit2c],
+    bitbay: ['Bitbay', ccxt.bitbay],
+    bitbays: ['Bitbays', ccxt.bitbays],
+    bitcoincoid: ['Bitcoincoid', ccxt.bitcoincoid],
+    // bitfinex: ['bitfinex', ccxt.bitfinex],
+    // bitfinex2: ['bitfinex2', ccxt.bitfinex2],
+    bitflyer: ['Bitflyer', ccxt.bitflyer],
+    bitlish: ['Bitlish', ccxt.bitlish],
+    bitmarket: ['Bitmarket', ccxt.bitmarket],
+    bitmex: ['Bitmex', ccxt.bitmex],
+    bitso: ['Bitso', ccxt.bitso],
+    bitstamp: ['Bitstamp', ccxt.bitstamp],
+    // bittRex: ['bittrex', ccxt.bittrex],
+    bl3p: ['BL3P', ccxt.bl3p],
+    btcchina: ['BTCchina', ccxt.btcchina],
+    btce: ['BTC-e', ccxt.btce],
+    btcexchange: ['BTC exchange', ccxt.btcexchange],
+    btcmarkets: ['BTC markets', ccxt.btcmarkets],
+    btctradeua: ['BTC tradeua', ccxt.btctradeua],
+    btcturk: ['BTC Turk', ccxt.btcturk],
+    btcx: ['BTC-x', ccxt.btcx],
+    bter: ['Bter', ccxt.bter],
+    bxinth: ['Bxinth', ccxt.bxinth],
+    ccex: ['C-cex', ccxt.ccex],
+    cex: ['Cex', ccxt.cex],
+    chbtc: ['Ch Btc', ccxt.chbtc],
+    chilebit: ['Chilebit', ccxt.chilebit],
+    coincheck: ['Coincheck', ccxt.coincheck],
+    coinfloor: ['Coinfloor', ccxt.coinfloor],
+    coingi: ['Coingi', ccxt.coingi],
+    coinmarketcap: ['Coinmarketcap', ccxt.coinmarketcap],
+    coinmate: ['Coinmate', ccxt.coinmate],
+    coinsecure: ['Coinsecure', ccxt.coinsecure],
+    coinspot: ['Coinspot', ccxt.coinspot],
+    cryptopia: ['Cryptopia', ccxt.cryptopia],
+    dsx: ['Dsx', ccxt.dsx],
+    exmo: ['Exmo', ccxt.exmo],
+    flowbtc: ['Flowbtc', ccxt.flowbtc],
+    foxbit: ['Foxbit', ccxt.foxbit],
+    fybse: ['Fybse', ccxt.fybse],
+    fybsg: ['Fybsg', ccxt.fybsg],
+    gatecoin: ['Gatecoin', ccxt.gatecoin],
+    // gdax: ['gdax', ccxt.gdax],
+    gemini: ['Gemini', ccxt.gemini],
+    hitbtc: ['Hitbtc', ccxt.hitbtc],
+    hitbtc2: ['Hitbtc2', ccxt.hitbtc2],
+    huobi: ['Huobi', ccxt.huobi],
+    itbit: ['Itbit', ccxt.itbit],
+    jubi: ['Jubi', ccxt.jubi],
+    kraken: ['Kraken', ccxt.kraken],
+    lakebtc: ['LakeBTC', ccxt.lakebtc],
+    livecoin: ['Livecoin', ccxt.livecoin],
+    liqui: ['Liqui', ccxt.liqui],
+    luno: ['Luno', ccxt.luno],
+    mercado: ['Mercado', ccxt.mercado],
+    okcoincny: ['Okcoincny', ccxt.okcoincny],
+    okcoinusd: ['Okcoinusd', ccxt.okcoinusd],
+    okex: ['Okex', ccxt.okex],
+    paymium: ['Paymium', ccxt.paymium],
+    // poloniex: ['poloniex', ccxt.poloniex],
+    quadrigacx: ['Quadrigacx', ccxt.quadrigacx],
+    quoine: ['Quoine', ccxt.quoine],
+    southxchange: ['Southxchange', ccxt.southxchange],
+    surbitcoin: ['Surbitcoin', ccxt.surbitcoin],
+    therock: ['Therock', ccxt.therock],
+    urdubit: ['Urdubit', ccxt.urdubit],
+    vaultoro: ['Vaultoro', ccxt.vaultoro],
+    vbtc: ['VBTC', ccxt.vbtc],
+    virwox: ['Virwox', ccxt.virwox],
+    xbtce: ['Xbtce', ccxt.xbtce],
+    yobit: ['Yobit', ccxt.yobit],
+    yunbi: ['Yunbi', ccxt.yunbi],
+    zaif: ['Zaif', ccxt.zaif]
+};
+
+export default class CCXTExchangeWrapper implements PublicExchangeAPI, AuthenticatedExchangeAPI, ExchangeTransferAPI {
+    static createExchange(name: string, auth: ExchangeAuthConfig, logger: Logger, opts: any = {}): CCXTExchangeWrapper {
+        const [owner, exchange] = exchanges[name];
+        const upName = name.toUpperCase();
+        const key = auth.key || process.env[`${upName}_KEY`];
+        const secret = auth.secret || process.env[`${upName}_SECRET`];
+        const password = opts.passphrase || process.env[`${upName}_PASSPHRASE`];
+        const uid = opts.uid || process.env[`${upName}_UID`];
+        const options = Object.assign(opts, { apiKey: key, secret: secret, uid: uid, password: password });
+        const ccxtInstance = exchange(options);
+        return new CCXTExchangeWrapper(owner, auth, ccxtInstance, logger);
+    }
+
+    static supportedExchanges(): string[] {
+        return Object.keys(exchanges);
+    }
+
+    static supportedExchangeNames(): string[] {
+        const result: string[] = [];
+        for (const x in exchanges) {
+            result.push(exchanges[x][0]);
+        }
+        return result;
+    }
+
+    readonly owner: string;
+    private instance: ccxt.Exchange;
+    private options: any;
+    private logger: Logger;
+
+    constructor(owner: string, opts: any, ccxtInstance: ccxt.Exchange, logger: Logger) {
+        this.owner = owner;
+        this.instance = ccxtInstance;
+        this.options = opts;
+        this.logger = logger;
+    }
+
+    log(level: string, msg: string, meta?: any) {
+        if (!this.logger) {
+            return;
+        }
+        this.logger.log(level, msg, meta);
+    }
+
+    loadProducts(): Promise<Product[]> {
+        return this.instance.loadMarkets(true).then((markets: ccxt.CCXTMarket[]) => {
+            if (!markets) {
+                return Promise.resolve([]);
+            }
+            const result: Product[] = [];
+            for (const id in markets) {
+                const m = markets[id];
+                const product: Product = {
+                    id: `${m.base}-${m.quote}`,
+                    sourceId: m.id,
+                    baseCurrency: m.base,
+                    quoteCurrency: m.quote,
+                    baseMinSize: m.info && (m.info.min || m.info.minimum_order_size),
+                    baseMaxSize: m.info && (m.info.max || m.info.maximum_order_size),
+                    quoteIncrement: m.info && (m.info.quote_increment || m.info.step),
+                    sourceData: m.info
+                };
+                result.push(product);
+            }
+            return Promise.resolve(result);
+        }).catch((err) => {
+            this.log('error', `Could not load products for ${this.owner}`, err);
+            return Promise.resolve([]);
+        });
+    }
+
+    loadMidMarketPrice(gdaxProduct: string): Promise<BigJS> {
+        return undefined;
+    }
+
+    loadOrderbook(gdaxProduct: string): Promise<BookBuilder> {
+        return undefined;
+    }
+
+    getSourceSymbol(gdaxProduct: string): Promise<string> {
+        const [base, quote] = gdaxProduct.split('-');
+        return this.instance.loadMarkets(false).then((markets: CCXTMarket[]) => {
+            for (const id in markets) {
+                const m: CCXTMarket = markets[id];
+                if (m.base === base && m.quote === quote) {
+                    return Promise.resolve(m.symbol);
+                }
+            }
+            return Promise.resolve(null);
+        });
+    }
+
+    loadTicker(gdaxProduct: string): Promise<Ticker> {
+        return this.getSourceSymbol(gdaxProduct).then((id: string) => {
+            return this.instance.fetchTicker(id);
+        }).then((ticker: any) => {
+            if (!ticker) {
+                return Promise.resolve(null);
+            }
+            const t: Ticker = {
+                productId: gdaxProduct,
+                price: Big(0),
+                time: new Date(ticker.timestamp),
+                ask: Big(ticker.bid),
+                bid: Big(ticker.ask),
+                volume: Big(ticker.baseVolume)
+            };
+            return Promise.resolve(t);
+        }).catch((err) => {
+            this.log('error', `Could not load ticker for ${gdaxProduct} on ${this.owner}`, err);
+            return Promise.resolve(null);
+        });
+    }
+
+    placeOrder(order: PlaceOrderMessage): Promise<LiveOrder> {
+        return undefined;
+    }
+
+    cancelOrder(id: string): Promise<string> {
+        return undefined;
+    }
+
+    cancelAllOrders(product: string): Promise<string[]> {
+        return undefined;
+    }
+
+    loadOrder(id: string): Promise<LiveOrder> {
+        return undefined;
+    }
+
+    loadAllOrders(gdaxProduct: string): Promise<LiveOrder[]> {
+        return undefined;
+    }
+
+    loadBalances(): Promise<Balances> {
+        return undefined;
+    }
+
+    requestCryptoAddress(cur: string): Promise<CryptoAddress> {
+        return undefined;
+    }
+
+    requestTransfer(request: TransferRequest): Promise<TransferResult> {
+        return undefined;
+    }
+
+    requestWithdrawal(request: WithdrawalRequest): Promise<TransferResult> {
+        return undefined;
+    }
+
+    transfer(cur: string, amount: BigJS, from: string, to: string, options: any): Promise<TransferResult> {
+        return undefined;
+    }
+}

--- a/src/exchanges/ccxt/index.ts
+++ b/src/exchanges/ccxt/index.ts
@@ -280,19 +280,19 @@ export default class CCXTExchangeWrapper implements PublicExchangeAPI, Authentic
     }
 
     cancelOrder(id: string): Promise<string> {
-        return undefined;
+        throw new Error('Not implemented yet');
     }
 
     cancelAllOrders(product: string): Promise<string[]> {
-        return undefined;
+        throw new Error('Not implemented yet');
     }
 
     loadOrder(id: string): Promise<LiveOrder> {
-        return undefined;
+        throw new Error('Not implemented yet');
     }
 
     loadAllOrders(gdaxProduct: string): Promise<LiveOrder[]> {
-        return undefined;
+        throw new Error('Not implemented yet');
     }
 
     loadBalances(): Promise<Balances> {
@@ -323,18 +323,18 @@ export default class CCXTExchangeWrapper implements PublicExchangeAPI, Authentic
     }
 
     requestCryptoAddress(cur: string): Promise<CryptoAddress> {
-        return undefined;
+        throw new Error('Not implemented yet');
     }
 
     requestTransfer(request: TransferRequest): Promise<TransferResult> {
-        return undefined;
+        throw new Error('Not implemented yet');
     }
 
     requestWithdrawal(request: WithdrawalRequest): Promise<TransferResult> {
-        return undefined;
+        throw new Error('Not implemented yet');
     }
 
     transfer(cur: string, amount: BigJS, from: string, to: string, options: any): Promise<TransferResult> {
-        return undefined;
+        throw new Error('Not implemented yet');
     }
 }

--- a/src/exchanges/gdax/GDAXExchangeAPI.ts
+++ b/src/exchanges/gdax/GDAXExchangeAPI.ts
@@ -112,11 +112,13 @@ export class GDAXExchangeAPI implements PublicExchangeAPI, AuthenticatedExchange
                 return products.map((prod: GDAXAPIProduct) => {
                     return {
                         id: prod.id,
+                        sourceId: prod.id,
                         baseCurrency: prod.base_currency,
                         quoteCurrency: prod.quote_currency,
                         baseMinSize: Big(prod.base_min_size),
                         baseMaxSize: Big(prod.base_max_size),
-                        quoteIncrement: Big(prod.quote_increment)
+                        quoteIncrement: Big(prod.quote_increment),
+                        sourceData: prod
                     } as Product;
                 });
             });

--- a/src/exchanges/poloniex/PoloniexCommon.ts
+++ b/src/exchanges/poloniex/PoloniexCommon.ts
@@ -57,11 +57,13 @@ export function gdaxifyProduct(poloProduct: string): Product {
     base = REVERSE_CURRENCY_MAP[base] || base;
     return {
         id: REVERSE_PRODUCT_MAP[poloProduct] || `${base}-${quote}`,
+        sourceId: poloProduct,
         quoteCurrency: quote,
         baseCurrency: base,
         baseMaxSize: Big(1e6),
         baseMinSize: Big(1e-6),
-        quoteIncrement: Big(1e-6)
+        quoteIncrement: Big(1e-6),
+        sourceData: null
     };
 }
 

--- a/src/samples/ccxtDemo.ts
+++ b/src/samples/ccxtDemo.ts
@@ -1,0 +1,50 @@
+/**********************************************************************************************************************
+ * @license                                                                                                           *
+ * Copyright 2017 Coinbase, Inc.                                                                                      *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License. You may obtain a copy of the License at                                                          *
+ *                                                                                                                    *
+ * http://www.apache.org/licenses/LICENSE-2.0                                                                         *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on*
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the                 *
+ * License for the specific language governing permissions and limitations under the License.                         *
+ **********************************************************************************************************************/
+
+import CCXTWrapper from '../exchanges/ccxt';
+import { printTicker } from '../utils/printers';
+import { ConsoleLoggerFactory } from '../utils/Logger';
+import { Product } from '../exchanges/PublicExchangeAPI';
+
+const exchanges = CCXTWrapper.supportedExchanges();
+const logger = ConsoleLoggerFactory();
+
+console.log(`${exchanges.length} Supported exchanges:`);
+console.log(exchanges.join(', '));
+
+console.log('Supported exchange names:');
+console.log(CCXTWrapper.supportedExchangeNames().join(', '));
+
+for (let i = 0; i < 5; i++) {
+    const exchange = randomElement(exchanges);
+    const api = CCXTWrapper.createExchange(exchange, { key: null, secret: null }, logger);
+    let product: Product;
+    api.loadProducts().then((products) => {
+        product = randomElement(products);
+        if (!product) {
+            return Promise.resolve(null);
+        }
+        console.log(`Loading ticker for ${product.id} on ${api.owner}`);
+        return api.loadTicker(product.id);
+    }).then((ticker) => {
+        console.log(`Ticker for ${product.id} on ${api.owner}`);
+        const s = ticker ? printTicker(ticker, 4) : '... is not available';
+        console.log(s);
+    });
+}
+
+function randomElement(array: any[]): any {
+    const index = Math.floor(Math.random() * array.length);
+    return array[index];
+}

--- a/src/samples/ccxtDemo.ts
+++ b/src/samples/ccxtDemo.ts
@@ -13,9 +13,10 @@
  **********************************************************************************************************************/
 
 import CCXTWrapper from '../exchanges/ccxt';
-import { printTicker } from '../utils/printers';
+import { printOrderbook, printTicker } from '../utils/printers';
 import { ConsoleLoggerFactory } from '../utils/Logger';
 import { Product } from '../exchanges/PublicExchangeAPI';
+import { BookBuilder } from '../lib/BookBuilder';
 
 const exchanges = CCXTWrapper.supportedExchanges();
 const logger = ConsoleLoggerFactory();
@@ -40,6 +41,11 @@ for (let i = 0; i < 5; i++) {
     }).then((ticker) => {
         console.log(`Ticker for ${product.id} on ${api.owner}`);
         const s = ticker ? printTicker(ticker, 4) : '... is not available';
+        console.log(s);
+        return api.loadOrderbook(product.id);
+    }).then((book: BookBuilder) => {
+        console.log(`Top 10 orders for ${product.id} on ${api.owner}`);
+        const s = book ? printOrderbook(book, 10, 4, 4): '... is not available';
         console.log(s);
     });
 }

--- a/src/samples/ccxtDemo.ts
+++ b/src/samples/ccxtDemo.ts
@@ -17,6 +17,7 @@ import { printOrderbook, printTicker } from '../utils/printers';
 import { ConsoleLoggerFactory } from '../utils/Logger';
 import { Product } from '../exchanges/PublicExchangeAPI';
 import { BookBuilder } from '../lib/BookBuilder';
+import { Balances } from '../exchanges/AuthenticatedExchangeAPI';
 
 const exchanges = CCXTWrapper.supportedExchanges();
 const logger = ConsoleLoggerFactory();
@@ -28,7 +29,8 @@ console.log('Supported exchange names:');
 console.log(CCXTWrapper.supportedExchangeNames().join(', '));
 
 for (let i = 0; i < 5; i++) {
-    const exchange = randomElement(exchanges);
+    // const exchange = randomElement(exchanges);
+    const exchange = ['bitmex', 'gemini', 'kraken', 'itbit', 'cex'][i];
     const api = CCXTWrapper.createExchange(exchange, { key: null, secret: null }, logger);
     let product: Product;
     api.loadProducts().then((products) => {
@@ -45,8 +47,15 @@ for (let i = 0; i < 5; i++) {
         return api.loadOrderbook(product.id);
     }).then((book: BookBuilder) => {
         console.log(`Top 10 orders for ${product.id} on ${api.owner}`);
-        const s = book ? printOrderbook(book, 10, 4, 4): '... is not available';
+        const s = book ? printOrderbook(book, 10, 4, 4) : '... is not available';
         console.log(s);
+        return api.loadBalances();
+    }).then((balances: Balances) => {
+        console.log(`Account balances for ${api.owner}`);
+        const s = balances ? JSON.stringify(balances) : '... are not available';
+        console.log(s);
+    }, () => {
+        console.log(`No Credentials provided for ${api.owner}.`);
     });
 }
 

--- a/src/utils/printers.ts
+++ b/src/utils/printers.ts
@@ -29,10 +29,11 @@ export function printOrderbook(book: Orderbook, numOrders: number = 20, basePrec
         const ask: PriceLevel = state.asks[i];
         totalAsks += +ask.totalSize;
         totalBids += +bid.totalSize;
-        report += (`${padfloat(totalBids, 9, basePrec)}  ${padfloat(bid.totalSize, 8, basePrec)}  $${padfloat(bid.price, 7, quotePrec)}\t\t` +
+        report += (`${padfloat(totalBids, 9, basePrec)}  ${padfloat(bid.totalSize, 8, basePrec)}  ${padfloat(bid.price, 7, quotePrec)}\t\t` +
         `${padfloat(ask.price, 7, quotePrec)}  ${padfloat(ask.totalSize, 8, basePrec)}  ${padfloat(totalAsks, 9, basePrec)}\n`);
     }
     return report;
+
 }
 
 export function printSeparator() {

--- a/types/ccxt.d.ts
+++ b/types/ccxt.d.ts
@@ -1,0 +1,212 @@
+// Type definitions for ccxt 0.1.0
+// Project: https://github.com/kroitor/ccxt
+// Definitions by: Cayle Sharrock <https://github.com/CjS77>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module 'ccxt' {
+
+    export interface CCXTMarket {
+        id: string;
+        symbol: string;
+        base: string;
+        quote: string;
+        info: any;
+    }
+
+    export class Exchange {
+        readonly rateLimit: number;
+        public verbose: boolean;
+        public substituteCommonCurrencyCodes: boolean;
+        public hasFetchTickers: boolean;
+
+        fetch(url: string, method: string, headers?: any, body?: any): Promise<any>;
+
+        handleResponse(url: string, method: string, headers?: any, body?: any): any;
+
+        loadMarkets(reload?: boolean): Promise<CCXTMarket[]>;
+
+        fetchOrderStatus(id: string, market: string): Promise<string>;
+
+        account(): any;
+
+        commonCurrencyCode(currency: string): string;
+
+        market(symbol: string): CCXTMarket;
+
+        marketId(symbol: string): string;
+
+        marketIds(symbols: string): string[];
+
+        symbol(symbol: string): string;
+
+        createOrder(market: string, type: string, side: string, amount: string, price?: string, params?: any): Promise<any>;
+
+        fetchBalance(params?: any): Promise<any>;
+
+        fetchOrderBook(market: string, params?: any): Promise<any>;
+
+        fetchTicker(market: string): Promise<any>;
+
+        fetchTrades(symbol: string, params?: any): Promise<any>;
+
+        cancelOrder(id: string): Promise<any>;
+
+        withdraw(currency: string, amount: string, address: string, params?: any): Promise<any>;
+
+        request(path: string, api: string, method: string, params?: any, headers?: any, body?: any): Promise<any>;
+    }
+
+    export function _1broker(options: any): Exchange;
+
+    export function _1btcxe(options: any): Exchange;
+
+    export function anxpro(options: any): Exchange;
+
+    export function binance(options: any): Exchange;
+
+    export function bit2c(options: any): Exchange;
+
+    export function bitbay(options: any): Exchange;
+
+    export function bitbays(options: any): Exchange;
+
+    export function bitcoincoid(options: any): Exchange;
+
+    export function bitfinex(options: any): Exchange;
+
+    export function bitfinex2(options: any): Exchange;
+
+    export function bitflyer(options: any): Exchange;
+
+    export function bitlish(options: any): Exchange;
+
+    export function bitmarket(options: any): Exchange;
+
+    export function bitmex(options: any): Exchange;
+
+    export function bitso(options: any): Exchange;
+
+    export function bitstamp(options: any): Exchange;
+
+    export function bittrex(options: any): Exchange;
+
+    export function bl3p(options: any): Exchange;
+
+    export function btcchina(options: any): Exchange;
+
+    export function btce(options: any): Exchange;
+
+    export function btcexchange(options: any): Exchange;
+
+    export function btcmarkets(options: any): Exchange;
+
+    export function btctradeua(options: any): Exchange;
+
+    export function btcturk(options: any): Exchange;
+
+    export function btcx(options: any): Exchange;
+
+    export function bter(options: any): Exchange;
+
+    export function bxinth(options: any): Exchange;
+
+    export function ccex(options: any): Exchange;
+
+    export function cex(options: any): Exchange;
+
+    export function chbtc(options: any): Exchange;
+
+    export function chilebit(options: any): Exchange;
+
+    export function coincheck(options: any): Exchange;
+
+    export function coinfloor(options: any): Exchange;
+
+    export function coingi(options: any): Exchange;
+
+    export function coinmarketcap(options: any): Exchange;
+
+    export function coinmate(options: any): Exchange;
+
+    export function coinsecure(options: any): Exchange;
+
+    export function coinspot(options: any): Exchange;
+
+    export function cryptopia(options: any): Exchange;
+
+    export function dsx(options: any): Exchange;
+
+    export function exmo(options: any): Exchange;
+
+    export function flowbtc(options: any): Exchange;
+
+    export function foxbit(options: any): Exchange;
+
+    export function fybse(options: any): Exchange;
+
+    export function fybsg(options: any): Exchange;
+
+    export function gatecoin(options: any): Exchange;
+
+    export function gdax(options: any): Exchange;
+
+    export function gemini(options: any): Exchange;
+
+    export function hitbtc(options: any): Exchange;
+
+    export function hitbtc2(options: any): Exchange;
+
+    export function huobi(options: any): Exchange;
+
+    export function itbit(options: any): Exchange;
+
+    export function jubi(options: any): Exchange;
+
+    export function kraken(options: any): Exchange;
+
+    export function lakebtc(options: any): Exchange;
+
+    export function livecoin(options: any): Exchange;
+
+    export function liqui(options: any): Exchange;
+
+    export function luno(options: any): Exchange;
+
+    export function mercado(options: any): Exchange;
+
+    export function okcoincny(options: any): Exchange;
+
+    export function okcoinusd(options: any): Exchange;
+
+    export function okex(options: any): Exchange;
+
+    export function paymium(options: any): Exchange;
+
+    export function poloniex(options: any): Exchange;
+
+    export function quadrigacx(options: any): Exchange;
+
+    export function quoine(options: any): Exchange;
+
+    export function southxchange(options: any): Exchange;
+
+    export function surbitcoin(options: any): Exchange;
+
+    export function therock(options: any): Exchange;
+
+    export function urdubit(options: any): Exchange;
+
+    export function vaultoro(options: any): Exchange;
+
+    export function vbtc(options: any): Exchange;
+
+    export function virwox(options: any): Exchange;
+
+    export function xbtce(options: any): Exchange;
+
+    export function yobit(options: any): Exchange;
+
+    export function yunbi(options: any): Exchange;
+
+    export function zaif(options: any): Exchange;
+}

--- a/types/ccxt.d.ts
+++ b/types/ccxt.d.ts
@@ -13,6 +13,13 @@ declare module 'ccxt' {
         info: any;
     }
 
+    export interface CCXTOrderbook {
+        bids: number[][];
+        asks: number[][];
+        timestamp: number;
+        datetime: string;
+    }
+
     export class Exchange {
         readonly rateLimit: number;
         public verbose: boolean;
@@ -43,7 +50,7 @@ declare module 'ccxt' {
 
         fetchBalance(params?: any): Promise<any>;
 
-        fetchOrderBook(market: string, params?: any): Promise<any>;
+        fetchOrderBook(market: string, params?: any): Promise<CCXTOrderbook>;
 
         fetchTicker(market: string): Promise<any>;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -98,6 +98,13 @@
   dependencies:
     "@types/node" "*"
 
+"JSONStream@>= 0.8.4":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"
+  dependencies:
+    jsonparse "^1.2.0"
+    through ">=2.2.7 <3"
+
 ajv@^4.9.1:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
@@ -361,6 +368,14 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
+ccxt@^1.6.72:
+  version "1.6.72"
+  resolved "https://registry.yarnpkg.com/ccxt/-/ccxt-1.6.72.tgz#16bc304fe40078974ebb9723cc24d943a5fd25ce"
+  dependencies:
+    crypto-js "3.1.9-1"
+    node-fetch "2.0.0-alpha.8"
+    qs "6.5.0"
+
 center-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/center-align/-/center-align-0.1.3.tgz#aa0d32629b6ee972200411cbd4461c907bc2b7ad"
@@ -501,6 +516,10 @@ cryptiles@2.x.x:
   dependencies:
     boom "2.x.x"
 
+crypto-js@3.1.9-1:
+  version "3.1.9-1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
+
 crypto@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/crypto/-/crypto-0.0.3.tgz#470a81b86be4c5ee17acc8207a1f5315ae20dbb0"
@@ -569,6 +588,10 @@ diff@^3.1.0, diff@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.0.tgz#056695150d7aa93237ca7e378ac3b1682b7963b9"
 
+duplexer@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
@@ -588,6 +611,18 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
+
+"event-stream@>= 3.1.5":
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
+  dependencies:
+    duplexer "~0.1.1"
+    from "~0"
+    map-stream "~0.1.0"
+    pause-stream "0.0.11"
+    split "0.3"
+    stream-combiner "~0.0.4"
+    through "~2.3.1"
 
 execa@^0.7.0:
   version "0.7.0"
@@ -719,6 +754,10 @@ formidable@^1.0.17:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.1.1.tgz#96b8886f7c3c3508b932d6bd70c4d3a88f35f1a9"
 
+from@~0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
+
 fs-extra@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.1.tgz#7fc0c6c8957f983f57f306a24e5b9ddd8d0dd880"
@@ -782,7 +821,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@7.0.5, glob@^7.0.0:
+glob@7.0.5:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.5.tgz#b4202a69099bbb4d292a7c1b95b6682b67ebdc95"
   dependencies:
@@ -793,7 +832,7 @@ glob@7.0.5, glob@^7.0.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.5, glob@^7.0.6, glob@^7.1.1:
+glob@^7.0.0, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -1126,9 +1165,17 @@ jsonfile@^3.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonic@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/jsonic/-/jsonic-0.3.0.tgz#b545da95f54392e58b3dda05f5f2e377a6c9d1bf"
+
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
+
+jsonparse@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
 
 jsonpointer@^4.0.0:
   version "4.0.1"
@@ -1343,6 +1390,10 @@ make-error@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.0.tgz#52ad3a339ccf10ce62b4040b708fe707244b8b96"
 
+map-stream@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
+
 marked@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
@@ -1482,9 +1533,24 @@ nock@9.0.2:
     propagate "0.4.0"
     qs "^6.0.2"
 
+node-fetch@2.0.0-alpha.8:
+  version "2.0.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.0.0-alpha.8.tgz#f586cf6730ce30431c7d4528ce561d81add8ba90"
+
 node-uuid@~1.4.7:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
+
+node.bittrex.api@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/node.bittrex.api/-/node.bittrex.api-0.5.1.tgz#d36ffff09364b36dd81c50a3b96c65bee22322b7"
+  dependencies:
+    JSONStream ">= 0.8.4"
+    event-stream ">= 3.1.5"
+    jsonic "^0.3.0"
+    object-assign "^4.1.1"
+    request ">= 2.35.0"
+    signalr-client "0.0.17"
 
 normalize-package-data@^2.3.2:
   version "2.4.0"
@@ -1553,7 +1619,7 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.1.0:
+object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -1658,6 +1724,12 @@ path-type@^2.0.0:
   dependencies:
     pify "^2.0.0"
 
+pause-stream@0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
+  dependencies:
+    through "~2.3"
+
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
@@ -1719,7 +1791,7 @@ pushbullet@2.0.0:
     request "^2.79.0"
     websocket "^1.0.24"
 
-qs@^6.0.2, qs@^6.1.0:
+qs@6.5.0, qs@^6.0.2, qs@^6.1.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.0.tgz#8d04954d364def3efc55b5a0793e1e2c8b1e6e49"
 
@@ -1856,7 +1928,7 @@ request@2.74.0:
     tough-cookie "~2.3.0"
     tunnel-agent "~0.4.1"
 
-request@^2.79.0:
+"request@>= 2.35.0", request@^2.79.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -1947,6 +2019,12 @@ signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
+signalr-client@0.0.17:
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/signalr-client/-/signalr-client-0.0.17.tgz#a52177f37ce248ecc87226dd103c41ff70c829b1"
+  dependencies:
+    websocket "^1.0.17"
+
 simple-mock@0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/simple-mock/-/simple-mock-0.8.0.tgz#49c9a223fa6eea8e2c4fd6948fe8300cd8a594f3"
@@ -2002,6 +2080,12 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
+split@0.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
+  dependencies:
+    through "2"
+
 sshpk@^1.7.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.1.tgz#512df6da6287144316dc4c18fe1cf1d940739be3"
@@ -2019,6 +2103,12 @@ sshpk@^1.7.0:
 stack-trace@0.0.x:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+
+stream-combiner@~0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
+  dependencies:
+    duplexer "~0.1.1"
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -2119,6 +2209,10 @@ test-exclude@^4.1.1:
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
+
+through@2, "through@>=2.2.7 <3", through@~2.3, through@~2.3.1:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
 to-fast-properties@^1.0.3:
   version "1.0.3"
@@ -2293,7 +2387,7 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-websocket@^1.0.24:
+websocket@^1.0.17, websocket@^1.0.24:
   version "1.0.24"
   resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.24.tgz#74903e75f2545b6b2e1de1425bc1c905917a1890"
   dependencies:


### PR DESCRIPTION
Adds kroitor/ccxt support for the GTT, which provides a unified API for over 70 exchanges.

Right now, only the public feeds are implemented.
