### PR TITLE
Handle new API feed messages

### DIFF
--- a/src/exchanges/gdax/GDAXFeed.ts
+++ b/src/exchanges/gdax/GDAXFeed.ts
@@ -389,12 +389,21 @@ export class GDAXFeed extends ExchangeFeed {
                 } as ErrorMessage;
                 this.emit('feed-error', msg);
                 return msg;
-            default:
+            case 'received':
                 return {
                     type: 'unknown',
                     time: new Date(),
                     sequence: (feedMessage as any).sequence,
                     productId: (feedMessage as any).product_id,
+                    message: feedMessage
+                } as UnknownMessage;
+            default:
+                const product: string = (feedMessage as any).product_id;
+                return {
+                    type: 'unknown',
+                    time: new Date(),
+                    sequence: this.getSequence(product),
+                    productId: product,
                     message: feedMessage
                 } as UnknownMessage;
         }


### PR DESCRIPTION
The only WS messages that need to be checked for sequence order on GDAX are from the "full" L3 (legacy) feed. For everything else, the internal sequence counter should be used

There are some new message types on the API feed, which got mis-characterized as full feed messages and were assigned the wrong message number.

This fixes #39