### PR TITLE
Add origin field to StreamMessage

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "ts-node": "^3.3.0",
     "tslint": "5.6.0",
     "typedoc": "0.8.0",
-    "typescript": "2.4.1",
+    "typescript": "^2.5.3",
     "uuid": "3.0.0"
   }
 }

--- a/src/core/Messages.ts
+++ b/src/core/Messages.ts
@@ -18,11 +18,14 @@ import { Ticker } from '../exchanges/PublicExchangeAPI';
  * Interfaces for the GTT Stream message types. These messages are generated and passed on my the GTT streaming
  * infrastructure. The `type` field is conventionally named after the interface, first letter lowercased,  with the word Message
  * stripped out, so e.g. HeartbeatMessage => heartbeat and NewOrderMessage => newOrder
+ *
+ * The origin field, if present represents the original unmodified message that was mapped (e.g. original trade message from exchange)
  */
 
 export interface StreamMessage {
     type: string;
     time: Date;
+    origin?: any;
 }
 
 export function isStreamMessage(msg: any): boolean {
@@ -38,10 +41,16 @@ export function isErrorMessage(msg: any): boolean {
     return isStreamMessage(msg) && !!msg.message && typeof msg.message === 'string';
 }
 
+/**
+ * Interface for any message type not supported explicitly elsewhere.
+ * The type must always be 'unknown'. If the source of the message is actually known, (e.g. trollbox chats), this can be indicated in the `tag` field.
+ * Any context-rich information can be extracted into the `extra` field, and the original message should be attached to the `origin` field as usual.
+ */
 export interface UnknownMessage extends StreamMessage {
     sequence?: number;
     productId?: string;
-    message: any;
+    tag?: string;
+    extra?: any;
 }
 
 export function isUnknownMessage(msg: any): boolean {

--- a/src/exchanges/ExchangeFeed.ts
+++ b/src/exchanges/ExchangeFeed.ts
@@ -133,6 +133,10 @@ export abstract class ExchangeFeed extends Readable {
     protected close() {
         // We're initiating the socket closure, so don't reconnect
         this.socket.removeAllListeners('close');
+        this.socket.removeAllListeners('message');
+        this.socket.removeAllListeners('open');
+        this.socket.removeAllListeners('close');
+        this.socket.removeAllListeners('connection');
         this.socket.close();
     }
 

--- a/src/exchanges/gdax/GDAXFeed.ts
+++ b/src/exchanges/gdax/GDAXFeed.ts
@@ -179,6 +179,9 @@ export class GDAXFeed extends ExchangeFeed {
                 case 'snapshot':
                     this.processSnapshot(this.createSnapshotMessage(feedMessage as GDAXSnapshotMessage));
                     return;
+                case 'last_match':
+                    message = this.mapMatchMessage(feedMessage as GDAXMatchMessage);
+                    break;
                 default:
                     message = this.mapFullFeed(feedMessage);
             }
@@ -474,7 +477,7 @@ export class GDAXFeed extends ExchangeFeed {
             default:
                 return {
                     type: 'unknown',
-                    message: feedMessage
+                    origin: feedMessage
                 } as UnknownMessage;
         }
     }

--- a/src/exchanges/poloniex/PoloniexFeed.ts
+++ b/src/exchanges/poloniex/PoloniexFeed.ts
@@ -176,7 +176,7 @@ export class PoloniexFeed extends ExchangeFeed {
             time: new Date(),
             productId: null,
             sequence: null,
-            message: msg
+            origin: msg
         };
         this.push(message);
     }
@@ -193,26 +193,30 @@ export class PoloniexFeed extends ExchangeFeed {
             reputation: +msg[4]
         };
         const message: UnknownMessage = {
-            type: 'poloniex-trollbox',
+            type: 'unknown',
+            tag: 'poloniex-trollbox',
             time: new Date(),
             productId: null,
             sequence: null,
-            message: chat
+            extra: chat,
+            origin: msg
         };
         this.push(message);
     }
 
     private handle_total_volume_message(msg: any[]): void {
         const message: UnknownMessage = {
-            type: 'poloniex-volume',
+            type: 'unknown',
+            tag: 'poloniex-volume',
             time: new Date(msg[2][0]),
             productId: null,
             sequence: msg[1],
-            message: {
+            extra: {
                 serverTime: msg[2][0],
                 usersOnline: msg[2][1],
                 volume: msg[2][2]
-            }
+            },
+            origin: msg
         };
         this.push(message);
     }
@@ -235,7 +239,8 @@ export class PoloniexFeed extends ExchangeFeed {
                 price: Big(data[1]),
                 bid: Big(data[3]),
                 ask: Big(data[2]),
-                volume: Big(data[4])
+                volume: Big(data[4]),
+                origin: msg
             };
             this.push(ticker);
         }).catch((err: Error) => {
@@ -245,11 +250,12 @@ export class PoloniexFeed extends ExchangeFeed {
 
     private handle_unknown_system_message(msg: any[]) {
         const message: UnknownMessage = {
-            type: 'poloniex-unknown',
+            type: 'unknown',
+            tag: 'poloniex-system',
             time: new Date(),
             productId: null,
             sequence: null,
-            message: msg
+            origin: msg
         };
         this.push(message);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2824,6 +2824,10 @@ typescript@2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.1.tgz#c3ccb16ddaa0b2314de031e7e6fee89e5ba346bc"
 
+typescript@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
+
 uglify-js@^2.6:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"


### PR DESCRIPTION
For greater flexibility, the original WS message can now be attached to the `StreamMessage` instance.

The GDAX and Polo streams have been updated to reflect this change.