### PR TITLE
Sanitize utility

### DIFF
--- a/src/core/Messages.ts
+++ b/src/core/Messages.ts
@@ -206,3 +206,24 @@ export interface MyOrderPlacedMessage extends StreamMessage {
     size: string;
     sequence: number;
 }
+
+/**
+ * Sanitises a message by replacing any keys in the msg object with '***'.
+ * Keys are searched recursively.
+ * The original message is not modified.
+ */
+export function sanitizeMessage(msg: { [index: string]: any }, sensitiveKeys: string[]) {
+    const clean: any = {};
+    for (const key in msg) {
+        if (msg.hasOwnProperty(key)) {
+            if (sensitiveKeys.includes(key)) {
+                clean[key] = '***';
+            } else if (typeof msg[key] === 'object') {
+                clean[key] = sanitizeMessage(msg[key], sensitiveKeys);
+            } else {
+                clean[key] = msg[key];
+            }
+        }
+    }
+    return clean;
+}

--- a/src/exchanges/ExchangeFeed.ts
+++ b/src/exchanges/ExchangeFeed.ts
@@ -55,11 +55,11 @@ export abstract class ExchangeFeed extends Readable {
         return this._logger;
     }
 
-    log(level: string, message: string, meta?: any, sanitize: boolean = true) {
+    log(level: string, message: string, meta?: any) {
         if (!this._logger) {
             return;
         }
-        if (sanitize && meta && typeof meta === 'object') {
+        if (meta && typeof meta === 'object') {
             meta = sanitizeMessage(meta, this.sensitiveKeys);
         }
         this._logger.log(level, message, meta);
@@ -195,9 +195,8 @@ export abstract class ExchangeFeed extends Readable {
 
     protected send(msg: any, cb?: (err: Error) => void): void {
         try {
-            const cleanMsg = typeof msg === 'object' ? JSON.stringify(sanitizeMessage(msg, this.sensitiveKeys)) : msg;
             const msgString = typeof(msg) === 'string' ? msg : JSON.stringify(msg);
-            this.log('debug', `Sending ${cleanMsg} message to WS server`);
+            this.log('debug', `Sending message to WS server`, { message: msg });
             this.socket.send(msgString, cb);
         } catch (err) {
             // If there's an error just log and carry on

--- a/src/exchanges/gdax/GDAXFeed.ts
+++ b/src/exchanges/gdax/GDAXFeed.ts
@@ -92,6 +92,7 @@ export class GDAXFeed extends ExchangeFeed {
             this.channels.push('heartbeat');
         }
         this.gdaxAPI = new GDAXExchangeAPI(config);
+        this.sensitiveKeys.push('passphrase');
         this.connect();
     }
 


### PR DESCRIPTION
Offer a `sanitizeMessage` function that will strip out any sensitive data in objects (as defined by the sensitiveKeys parameter)

Add `SanitizedLoggerFactory`, which that acts exactly like ConsoleLogger, except that it runs any metadata through messageSanitizer.

Sanitize some FeedExchange messages.