### PR TITLE
FailoverProvider

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gdax-trading-toolkit",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "A trading toolkit for building advanced trading bots on the GDAX platform",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gdax-trading-toolkit",
-  "version": "0.1.22",
+  "version": "0.1.21",
   "description": "A trading toolkit for building advanced trading bots on the GDAX platform",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/src/FXService/FXProvider.ts
+++ b/src/FXService/FXProvider.ts
@@ -104,6 +104,8 @@ export abstract class FXProvider {
         });
     }
 
+    abstract supportsPair(pair: CurrencyPair): Promise<boolean>;
+
     /**
      * Returns a promise for the current rate. IsSupported must be true, and is not checked here. The method returns a
      * promise for the current network request, or generates a new one.
@@ -132,6 +134,4 @@ export abstract class FXProvider {
      * @param pair
      */
     protected abstract downloadCurrentRate(pair: CurrencyPair): Promise<FXObject>;
-
-    protected abstract supportsPair(pair: CurrencyPair): Promise<boolean>;
 }

--- a/src/FXService/providers/OpenExchangeProvider.ts
+++ b/src/FXService/providers/OpenExchangeProvider.ts
@@ -37,6 +37,19 @@ export default class OpenExchangeProvider extends FXProvider {
         return 'Open Exchange Rates';
     }
 
+    supportsPair(pair: CurrencyPair): Promise<boolean> {
+        if (supportedCurrencies) {
+            return Promise.resolve(isSupported(pair));
+        }
+        return request.get(API_URL + '/currencies.json')
+            .accept('application/json')
+            .then((res: Response) => {
+                const curs: { [cur: string]: string } = res.body;
+                supportedCurrencies = Object.keys(curs);
+                return Promise.resolve(isSupported(pair));
+            });
+    }
+
     protected downloadCurrentRate(pair: CurrencyPair): Promise<FXObject> {
         const query = {
             base: pair.from,
@@ -59,19 +72,6 @@ export default class OpenExchangeProvider extends FXProvider {
                     rate: new Big(rate),
                     time: new Date()
                 });
-            });
-    }
-
-    protected supportsPair(pair: CurrencyPair): Promise<boolean> {
-        if (supportedCurrencies) {
-            return Promise.resolve(isSupported(pair));
-        }
-        return request.get(API_URL + '/currencies.json')
-            .accept('application/json')
-            .then((res: Response) => {
-                const curs: { [cur: string]: string } = res.body;
-                supportedCurrencies = Object.keys(curs);
-                return Promise.resolve(isSupported(pair));
             });
     }
 }

--- a/src/utils/promises.ts
+++ b/src/utils/promises.ts
@@ -52,3 +52,26 @@ export function eachParallelAndFinish<T, U>(arr: T[], iteratorFn: (arg: T) => Pr
         });
     });
 }
+
+/**
+ * Applies iteratorFn to each element in arr until a 'true' result is returned. Rejected promises are swallowed. A false result is returned only
+ * if every iteratorFn(i) returns false or an Error
+ */
+export function tryUntil<T, U>(arr: T[], iteratorFn: (arg: T) => Promise<U | boolean>, index: number = 0): Promise<U | boolean> {
+    if (arr.length < 1) {
+        return Promise.resolve(false);
+    }
+    return iteratorFn(arr[index]).then((result: U | boolean) => {
+       if (result !== false) {
+           return Promise.resolve(result);
+       }
+       if (++index >= arr.length) {
+           return Promise.resolve(false);
+       }
+       return tryUntil(arr, iteratorFn, index);
+    }).catch(() => {
+        // Swallow the error and continue
+        const clone: T[] = arr.slice();
+        return tryUntil(clone.splice(0,1), iteratorFn);
+    });
+}

--- a/test/FXService/CryptoProviderTest.ts
+++ b/test/FXService/CryptoProviderTest.ts
@@ -1,0 +1,110 @@
+/**********************************************************************************************************************
+ * @license                                                                                                           *
+ * Copyright 2017 Coinbase, Inc.                                                                                      *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License. You may obtain a copy of the License at                                                          *
+ *                                                                                                                    *
+ * http://www.apache.org/licenses/LICENSE-2.0                                                                         *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on*
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the                 *
+ * License for the specific language governing permissions and limitations under the License.                         *
+ **********************************************************************************************************************/
+import { PublicExchangeAPI } from '../../src/exchanges/PublicExchangeAPI';
+import { CryptoProvider } from '../../src/FXService/providers/CryptoProvider';
+import { DefaultAPI } from '../../src/factories/gdaxFactories';
+import { NullLogger } from '../../src/utils/Logger';
+import { EFXRateUnavailable, FXObject } from '../../src/FXService/FXProvider';
+
+const assert = require('assert');
+const nock = require('nock');
+
+describe('CryptoProvider', () => {
+    let exchange: PublicExchangeAPI;
+    let provider: CryptoProvider;
+
+    before(() => {
+        exchange = DefaultAPI(NullLogger);
+        provider = new CryptoProvider({
+            exchange: exchange,
+            logger: NullLogger
+        });
+    });
+
+    it('returns true for supported currencies', () => {
+        nock('https://api.gdax.com')
+            .get('/products')
+            .reply(200, [{
+                id: 'BTC-USD',
+                base_currency: 'BTC',
+                quote_currency: 'USD',
+                base_min_size: '0.01',
+                base_max_size: '1000000',
+                quote_increment: '0.01',
+                display_name: 'BTC/USD'
+            }]);
+        return provider.supportsPair({ from: 'BTC', to: 'USD' }).then((result: boolean) => {
+            assert.equal(result, true);
+        });
+    });
+
+    it('returns false for unsupported currencies', () => {
+        return provider.supportsPair({ from: 'USD', to: 'XYZ' }).then((result: boolean) => {
+            assert.equal(result, false);
+        });
+    });
+
+    it('returns 1.0 for identities', () => {
+        return provider.fetchCurrentRate({ from: 'XYZ', to: 'XYZ' }).then((result: FXObject) => {
+            assert.equal(result.rate.toNumber(), 1.0);
+            assert.equal(result.from, 'XYZ');
+            assert.equal(result.to, 'XYZ');
+        });
+    });
+
+    it('returns spot rate for supported currencies', () => {
+        nock('https://api.gdax.com:443')
+            .get('/products/BTC-USD/ticker')
+            .reply(200, {
+                trade_id: 10000,
+                price: '10500.00',
+                bid: '10400.00',
+                ask: '10600.00',
+                time: '2017-10-26T06:17:41.579000Z'
+            });
+        return provider.fetchCurrentRate({ from: 'BTC', to: 'USD' }).then((result: FXObject) => {
+            assert.equal(result.rate.toNumber(), 10500);
+            assert.equal(result.from, 'BTC');
+            assert.equal(result.to, 'USD');
+        });
+    });
+
+    it('returns inverse spot rate for supported currencies', () => {
+        nock('https://api.gdax.com:443')
+            .get('/products/BTC-USD/ticker')
+            .reply(200, {
+                trade_id: 10000,
+                price: '10500.00',
+                bid: '10400.00',
+                ask: '10600.00',
+                time: '2017-10-26T06:17:41.579000Z'
+            });
+        return provider.fetchCurrentRate({ from: 'USD', to: 'BTC' }).then((result: FXObject) => {
+            assert.equal(result.rate.toNumber(), 1 / 10500);
+            assert.equal(result.from, 'USD');
+            assert.equal(result.to, 'BTC');
+        });
+    });
+
+    it('rejects for unsupported currencies', () => {
+        nock('https://api.gdax.com:443')
+            .get('/products/BTC-XYZ/ticker')
+            .reply(404, { message: 'NotFound' });
+        return provider.fetchCurrentRate({ from: 'BTC', to: 'XYZ' }).then((result: FXObject) => {
+            throw new Error('should reject this promise');
+        }).catch((err: Error) => {
+            assert.ok(err instanceof EFXRateUnavailable);
+        });
+    });
+});

--- a/test/FXService/FailoverProviderTest.ts
+++ b/test/FXService/FailoverProviderTest.ts
@@ -1,0 +1,162 @@
+/**********************************************************************************************************************
+ * @license                                                                                                           *
+ * Copyright 2017 Coinbase, Inc.                                                                                      *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License. You may obtain a copy of the License at                                                          *
+ *                                                                                                                    *
+ * http://www.apache.org/licenses/LICENSE-2.0                                                                         *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on*
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the                 *
+ * License for the specific language governing permissions and limitations under the License.                         *
+ **********************************************************************************************************************/
+
+import { CryptoProvider } from '../../src/FXService/providers/CryptoProvider';
+import { NullLogger } from '../../src/utils/Logger';
+import { FailoverProvider } from '../../src/FXService/providers/FailoverProvider';
+import { DefaultAPI as GDAX } from '../../src/factories/gdaxFactories';
+import { DefaultAPI as Bitfinex } from '../../src/factories/bitfinexFactories';
+import { EFXRateUnavailable, FXObject } from '../../src/FXService/FXProvider';
+
+const assert = require('assert');
+const nock = require('nock');
+
+describe('CryptoProvider', () => {
+    let provider: FailoverProvider;
+
+    before(() => {
+        provider = new FailoverProvider({
+            logger: NullLogger,
+            providers: [
+                new CryptoProvider({ logger: NullLogger, exchange: GDAX(NullLogger) }),
+                new CryptoProvider({ logger: NullLogger, exchange: Bitfinex(NullLogger) })
+            ]
+        });
+    });
+
+    it('supports currencies from first provider first', () => {
+        nock('https://api.gdax.com')
+            .get('/products')
+            .reply(200, [{
+                id: 'BTC-USD',
+                base_currency: 'BTC',
+                quote_currency: 'USD',
+                base_min_size: '0.01',
+                base_max_size: '1000000',
+                quote_increment: '0.01',
+                display_name: 'BTC/USD'
+            }]);
+        return provider.supportsPair({ from: 'BTC', to: 'USD' }).then((result: boolean) => {
+            assert.equal(result, true);
+        });
+    });
+
+    it('supports currencies from 2nd provider if first does not', () => {
+        nock('https://api.bitfinex.com:443')
+            .get('/v1/symbols_details')
+            .reply(200, [{
+                pair: 'ethusd',
+                price_precision: 5,
+                initial_margin: '30.0',
+                minimum_margin: '15.0',
+                maximum_order_size: '2000.0',
+                minimum_order_size: '0.004',
+                expiration: 'NA'
+            }]);
+        return provider.supportsPair({ from: 'ETH', to: 'USD' }).then((result: boolean) => {
+            assert.equal(result, true);
+        });
+    });
+
+    it('returns false for unsupported currencies', () => {
+        return provider.supportsPair({ from: 'USD', to: 'XYZ' }).then((result: boolean) => {
+            assert.equal(result, false);
+        });
+    });
+
+    it('returns 1.0 for identities', () => {
+        return provider.fetchCurrentRate({ from: 'XYZ', to: 'XYZ' }).then((result: FXObject) => {
+            assert.equal(result.rate.toNumber(), 1.0);
+            assert.equal(result.from, 'XYZ');
+            assert.equal(result.to, 'XYZ');
+        });
+    });
+
+    it('returns spot rate from first provider is supported', () => {
+        nock('https://api.gdax.com:443')
+            .get('/products/BTC-USD/ticker')
+            .reply(200, {
+                trade_id: 10000,
+                price: '10500.00',
+                bid: '10400.00',
+                ask: '10600.00',
+                time: '2017-10-26T06:17:41.579000Z'
+            });
+        return provider.fetchCurrentRate({ from: 'BTC', to: 'USD' }).then((result: FXObject) => {
+            assert.equal(result.rate.toNumber(), 10500);
+            assert.equal(result.from, 'BTC');
+            assert.equal(result.to, 'USD');
+        });
+    });
+
+    it('returns inverse spot rate from first provider if supported', () => {
+        nock('https://api.gdax.com:443')
+            .get('/products/BTC-USD/ticker')
+            .reply(200, {
+                trade_id: 10000,
+                price: '10500.00',
+                bid: '10400.00',
+                ask: '10600.00',
+                time: '2017-10-26T06:17:41.579000Z'
+            });
+        return provider.fetchCurrentRate({ from: 'USD', to: 'BTC' }).then((result: FXObject) => {
+            assert.equal(result.rate.toNumber(), 1 / 10500);
+            assert.equal(result.from, 'USD');
+            assert.equal(result.to, 'BTC');
+        });
+    });
+
+    it('returns spot rate from 2nd provider is first is not supported', () => {
+        nock('https://api.bitfinex.com:443')
+            .get('/v1/pubticker/ethusd')
+            .reply(200, {
+                mid: '500.00',
+                bid: '499.00',
+                ask: '501.00',
+                last_price: '495.49',
+            });
+        return provider.fetchCurrentRate({ from: 'ETH', to: 'USD' }).then((result: FXObject) => {
+            assert.equal(result.rate.toNumber(), 500);
+            assert.equal(result.from, 'ETH');
+            assert.equal(result.to, 'USD');
+        });
+    });
+
+    it('returns inverse spot rate from 2nd provider is first is not supported', () => {
+        nock('https://api.bitfinex.com:443')
+            .get('/v1/pubticker/ethusd')
+            .reply(200, {
+                mid: '500.00',
+                bid: '499.00',
+                ask: '501.00',
+                last_price: '495.49',
+            });
+        return provider.fetchCurrentRate({ from: 'USD', to: 'ETH' }).then((result: FXObject) => {
+            assert.equal(result.rate.toNumber(), 1 / 500);
+            assert.equal(result.from, 'USD');
+            assert.equal(result.to, 'ETH');
+        });
+    });
+
+    it('rejects for unsupported currencies', () => {
+        nock('https://api.gdax.com:443')
+            .get('/products/BTC-XYZ/ticker')
+            .reply(404, { message: 'NotFound' });
+        return provider.fetchCurrentRate({ from: 'BTC', to: 'XYZ' }).then((result: FXObject) => {
+            throw new Error('should reject this promise');
+        }).catch((err: Error) => {
+            assert.ok(err instanceof EFXRateUnavailable);
+        });
+    });
+});


### PR DESCRIPTION
Introducing FailoverProvider - an FXProvider class that takes an array of FXProvider instances in its constructor.
When a spot rate is requested, the first provider in the list is used. If that is not available or returns an error, it tries the second one, and so on.

Visibility on supportsPair was changed to allow this implementation. It has changed from protected to public