### PR TITLE
Add new Errors API

### DIFF
--- a/src/core/Messages.ts
+++ b/src/core/Messages.ts
@@ -35,7 +35,14 @@ export function isStreamMessage(msg: any): boolean {
 export interface ErrorMessage extends StreamMessage {
     type: 'error';
     message: string;
-    details?: any;
+    cause: any;
+}
+
+export interface HTTPErrorMessage extends ErrorMessage {
+    cause: {
+        status: number;
+        body: any;
+    };
 }
 
 export function isErrorMessage(msg: any): boolean {

--- a/src/exchanges/bitmex/BitmexMarketFeed.ts
+++ b/src/exchanges/bitmex/BitmexMarketFeed.ts
@@ -66,7 +66,8 @@ export class BitmexMarketFeed extends ExchangeFeed {
             const errMsg: ErrorMessage = {
                 type: 'error',
                 time: new Date(),
-                message: `Error while subscribing to symbols: ${msg.error}`,
+                message: `Error while subscribing to symbols`,
+                cause: msg.error
             };
 
             this.push(errMsg);

--- a/src/exchanges/gdax/GDAXFeed.ts
+++ b/src/exchanges/gdax/GDAXFeed.ts
@@ -389,7 +389,7 @@ export class GDAXFeed extends ExchangeFeed {
                     type: 'error',
                     time: new Date(),
                     message: error.message,
-                    details: { reason: error.reason }
+                    cause: error.reason
                 } as ErrorMessage;
                 this.emit('feed-error', msg);
                 return msg;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,95 @@
+/**********************************************************************************************************************
+ * @license                                                                                                           *
+ * Copyright 2017 Coinbase, Inc.                                                                                      *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License. You may obtain a copy of the License at                                                          *
+ *                                                                                                                    *
+ * http://www.apache.org/licenses/LICENSE-2.0                                                                         *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on*
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the                 *
+ * License for the specific language governing permissions and limitations under the License.                         *
+ **********************************************************************************************************************/
+import { ErrorMessage, HTTPErrorMessage } from '../core/Messages';
+
+export interface StreamError {
+    asMessage: () => ErrorMessage;
+}
+
+/**
+ * Errors raised as a result of an internal exception raised by GTT code.
+ */
+export class GTTError extends Error implements StreamError {
+    readonly cause: Error;
+    readonly time: Date;
+
+    constructor(msg: string, err?: Error) {
+        super(msg);
+        this.cause = err;
+        this.time = new Date();
+    }
+
+    asMessage(): ErrorMessage {
+        return {
+            type: 'error',
+            time: this.time,
+            message: this.message,
+            cause: this.cause ? this.cause.message : undefined
+        };
+    }
+}
+
+/**
+ * Errors raised or captured as a result of errors coming from external network sources, such as WS Feeds or REST APIs
+ */
+export class APIError extends Error implements StreamError {
+    readonly cause: any;
+    readonly time: Date;
+
+    constructor(msg: string, cause: any) {
+        super(msg);
+        this.cause = cause;
+        this.time = new Date();
+    }
+
+    asMessage(): ErrorMessage {
+        return {
+            type: 'error',
+            time: this.time,
+            message: this.message,
+            cause: this.cause
+        };
+    }
+}
+
+export interface ResponseLike {
+    status: number;
+    body: any;
+}
+
+/**
+ * Errors raised due to failures from REST API calls. The response status and body are returned in the `cause` object.
+ */
+export class HTTPError extends Error implements StreamError {
+    readonly response: ResponseLike;
+    readonly time: Date;
+
+    constructor(msg: string, res: ResponseLike) {
+        super(msg);
+        this.time = new Date();
+        this.response = res || { status: undefined, body: undefined };
+    }
+
+    asMessage(): HTTPErrorMessage {
+        return {
+            type: 'error',
+            time: this.time,
+            message: this.message,
+            cause: {
+                status: this.response.status,
+                body: this.response.body
+            }
+        };
+    }
+}

--- a/test/lib/errorsTest.ts
+++ b/test/lib/errorsTest.ts
@@ -1,0 +1,85 @@
+/**********************************************************************************************************************
+ * @license                                                                                                           *
+ * Copyright 2017 Coinbase, Inc.                                                                                      *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License. You may obtain a copy of the License at                                                          *
+ *                                                                                                                    *
+ * http://www.apache.org/licenses/LICENSE-2.0                                                                         *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on*
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the                 *
+ * License for the specific language governing permissions and limitations under the License.                         *
+ **********************************************************************************************************************/
+
+import assert = require('assert');
+import { APIError, GTTError, HTTPError, ResponseLike } from '../../src/lib/errors';
+import { ErrorMessage } from '../../src/core/Messages';
+
+describe('GTTError', () => {
+    it('accepts an error as metadata', () => {
+        const err = new GTTError('GTT Error Test 1', new Error('a bug'));
+        const msg: ErrorMessage = err.asMessage();
+        assert.equal(msg.type, 'error');
+        assert.ok(msg.time);
+        assert.equal(msg.message, 'GTT Error Test 1');
+        assert.equal(msg.cause, 'a bug');
+    });
+
+    it('behaves like a standard error', () => {
+        const err = new GTTError('GTT Error Test 2');
+        const msg: ErrorMessage = err.asMessage();
+        assert.equal(msg.type, 'error');
+        assert.ok(msg.time);
+        assert.equal(msg.message, 'GTT Error Test 2');
+        assert.equal(msg.cause, undefined);
+    });
+});
+
+describe('APIError', () => {
+    it('accepts a cause', () => {
+        const cause: any = { reason: 'That thing' };
+        const err = new APIError('API Error Test 1', cause);
+        const msg: ErrorMessage = err.asMessage();
+        assert.equal(msg.type, 'error');
+        assert.ok(msg.time);
+        assert.equal(msg.message, 'API Error Test 1');
+        assert.deepEqual(msg.cause, cause);
+    });
+
+    it('acts like a standard Error', () => {
+        const err = new APIError('API Error Test 2', null);
+        const msg: ErrorMessage = err.asMessage();
+        assert.equal(msg.type, 'error');
+        assert.ok(msg.time);
+        assert.equal(msg.message, 'API Error Test 2');
+        assert.deepEqual(msg.cause, null);
+    });
+});
+
+describe('HTTPError', () => {
+    it('accepts a response', () => {
+        const response: ResponseLike = {
+            status: 403, body: {
+                message: 'Invalid API key'
+            }
+        };
+        const err = new HTTPError('HTTP Error Test 1', response);
+        const msg: ErrorMessage = err.asMessage();
+        assert.equal(msg.type, 'error');
+        assert.ok(msg.time);
+        assert.equal(msg.message, 'HTTP Error Test 1');
+        assert.deepEqual(msg.cause.status, 403);
+        assert.deepEqual(msg.cause.body.message, 'Invalid API key');
+    });
+
+    it('accepts a null response', () => {
+        const err = new HTTPError('HTTP Error Test 2', null);
+        const msg: ErrorMessage = err.asMessage();
+        assert.equal(msg.type, 'error');
+        assert.ok(msg.time);
+        assert.equal(msg.message, 'HTTP Error Test 2');
+        assert.deepEqual(msg.cause.status, undefined);
+        assert.deepEqual(msg.cause.body, undefined);
+    });
+});


### PR DESCRIPTION
We introduce a set of Error classes that cn
i) capture the underlying `cause` of the error
ii) implement a common interface that can emit the message as a stream error

`GTTError` is typically raised as a result of an internal exception raised by GTT code.
`APIError` is typically raised or captured as a result of errors coming from external network sources, such as WS Feeds
`HTTPError` is specifically designed to capture errors from HTTP requests and return the actual response along with the error.