### PR TITLE
Exchanges should use Error API

### DIFF
--- a/src/exchanges/PublicExchangeAPI.ts
+++ b/src/exchanges/PublicExchangeAPI.ts
@@ -28,22 +28,22 @@ export interface PublicExchangeAPI {
     readonly owner: string;
 
     /**
-     * Load the list of supported products on this exchange
+     * Load the list of supported products on this exchange. Resolves with a list of products, or otherwise rejects the Promise with an HTTPError
      */
     loadProducts(): Promise<Product[]>;
 
     /**
-     * Load the mid-market price from the exchange's ticker
+     * Load the mid-market price from the exchange's ticker. Resolves with the latest midmarket price, or else rejects with an HTTPError
      */
     loadMidMarketPrice(gdaxProduct: string): Promise<BigJS>;
 
     /**
-     * Load the order book from the REST API and return an aggregated book as a #{../core/BookBuilder} object
+     * Load the order book from the REST API and resolves as an aggregated book as a #{../core/BookBuilder} object, otherwise the promise is rejected with an HTTPError
      */
     loadOrderbook(gdaxProduct: string): Promise<BookBuilder>;
 
     /**
-     * Load the ticker for the configured product from the REST API
+     * Load the ticker for the configured product from the REST API, Resolves with the latest ticker object, or else rejects with an HTTPError
      */
     loadTicker(gdaxProduct: string): Promise<Ticker>;
 }

--- a/src/exchanges/gdax/GDAXInterfaces.ts
+++ b/src/exchanges/gdax/GDAXInterfaces.ts
@@ -60,3 +60,8 @@ export interface GDAXAPIProduct {
     quote_increment: string;
     display_name: string;
 }
+
+export interface GDAXHTTPError {
+    message: string;
+    response: any;
+}

--- a/src/exchanges/utils.ts
+++ b/src/exchanges/utils.ts
@@ -16,6 +16,7 @@ import request = require('superagent');
 import crypto = require('crypto');
 import Response = request.Response;
 import { ExchangeAuthConfig } from './AuthConfig';
+import { extractResponse, HTTPError } from '../lib/errors';
 
 /**
  * A generic API response handler.
@@ -28,14 +29,9 @@ export function handleResponse<T>(req: Promise<Response>, meta: any): Promise<T>
         if (res.status >= 200 && res.status < 300) {
             return Promise.resolve<T>(res.body as T);
         }
-        const err: any = new Error(res.body.message);
-        err.details = res.body;
-        return Promise.reject(err);
+        return Promise.reject(new HTTPError('Error in Bitfinex request', extractResponse(res)));
     }).catch((err) => {
-        const reason: any = err.response.body;
-        const error: any = Object.assign(new Error('An API request failed. ' + reason.message), meta);
-        error.reason = reason;
-        return Promise.reject(error);
+        return Promise.reject(new HTTPError('Error in Bitfinex request', extractResponse(err.response)));
     });
 }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -93,3 +93,16 @@ export class HTTPError extends Error implements StreamError {
         };
     }
 }
+
+export function extractResponse(res: ResponseLike): ResponseLike {
+    if (!res) {
+        return {
+            status: undefined,
+            body: undefined
+        };
+    }
+    return {
+        status: res.status,
+        body: res.body
+    };
+}

--- a/src/samples/poloAuthDemo.ts
+++ b/src/samples/poloAuthDemo.ts
@@ -15,6 +15,7 @@ import * as Polo from '../factories/poloniexFactories';
 import { Balances } from '../exchanges/AuthenticatedExchangeAPI';
 import { ConsoleLoggerFactory } from '../utils/Logger';
 import { Product } from '../exchanges/PublicExchangeAPI';
+import { StreamError } from '../lib/errors';
 
 const logger = ConsoleLoggerFactory({ level: 'info' });
 const polo = Polo.DefaultAPI(logger);
@@ -30,6 +31,6 @@ polo.loadBalances()
     .then((balances: Balances) => {
         logger.log('info', JSON.stringify(balances));
     })
-    .catch((err: Error) => {
-        logger.log('error', err.message, err);
+    .catch((err: StreamError) => {
+        logger.log('error', 'Poloniex Error', err.asMessage());
     });

--- a/types/ccxt.d.ts
+++ b/types/ccxt.d.ts
@@ -42,6 +42,7 @@ declare module 'ccxt' {
         public verbose: boolean;
         public substituteCommonCurrencyCodes: boolean;
         public hasFetchTickers: boolean;
+        public name: string;
 
         fetch(url: string, method: string, headers?: any, body?: any): Promise<any>;
 


### PR DESCRIPTION
Update REST interfaces for exchanges to use Error API.

This introduces possibly breaking changes if you rely on text for error messages.