### PR TITLE
Fixed tutorial t003_tickertape.ts

### DIFF
--- a/tutorials/t003_tickertape.ts
+++ b/tutorials/t003_tickertape.ts
@@ -17,7 +17,8 @@ import {
     BitfinexConfig,
     BitfinexExchangeAPI
 } from "gdax-trading-toolkit/build/src/exchanges/bitfinex/BitfinexExchangeAPI";
-import { GDAXConfig, GDAXExchangeAPI } from "gdax-trading-toolkit/build/src/exchanges/gdax/GDAXExchangeAPI";
+import { GDAXConfig } from "gdax-trading-toolkit/build/src/exchanges/gdax/GDAXInterfaces";
+import { GDAXExchangeAPI } from "gdax-trading-toolkit/build/src/exchanges/gdax/GDAXExchangeAPI";
 import { PublicExchangeAPI, Ticker } from "gdax-trading-toolkit/build/src/exchanges/PublicExchangeAPI";
 
 const padfloat = GTT.utils.padfloat;


### PR DESCRIPTION
The example can now be run by doing:
```bash
git clone ...
yarn add gdax-trading-toolkit
yarn
yarn ts-node tutorials/t003_tickertape.ts
```

This is the error I used to get:
```bash
yarn ts-node tutorials/t003_tickertape.ts 
yarn run v1.3.2
$ /gdax-tt/node_modules/.bin/ts-node tutorials/t003_tickertape.ts

/gdax-tt/node_modules/ts-node/src/index.ts:307
        throw new TSError(formatDiagnostics(diagnosticList, cwd, ts, lineOffset))
              ^
TSError: ⨯ Unable to compile TypeScript
tutorials/t003_tickertape.ts (20,10): Module '"/gdax-tt/node_modules/gdax-trading-toolkit/build/src/exchanges/gdax/GDAXExchangeAPI"' has no exported member 'GDAXConfig'. (2305)
    at getOutput (/gdax-tt/node_modules/ts-node/src/index.ts:307:15)
    at /gdax-tt/node_modules/ts-node/src/index.ts:336:16
    at Object.compile (/gdax-tt/node_modules/ts-node/src/index.ts:498:11)
    at Module.m._compile (/gdax-tt/node_modules/ts-node/src/index.ts:392:43)
    at Module._extensions..js (module.js:623:10)
    at Object.require.extensions.(anonymous function) [as .ts] (/gdax-tt/node_modules/ts-node/src/index.ts:395:12)
    at Module.load (module.js:531:32)
    at tryModuleLoad (module.js:494:12)
    at Function.Module._load (module.js:486:3)
    at Function.Module.runMain (module.js:653:10)
error Command failed with exit code 1.
```