### PR TITLE
Fix Poloniex reconnection bug

### DIFF
--- a/src/exchanges/poloniex/PoloniexFeed.ts
+++ b/src/exchanges/poloniex/PoloniexFeed.ts
@@ -137,7 +137,7 @@ export class PoloniexFeed extends ExchangeFeed {
         this.subscriptions = {};
         for (const key in oldSubscriptions) {
             const channel = oldSubscriptions[key];
-            this.subscribe(channel.id);
+            this.resubscribe(channel.id);
         }
         this.pinger = setInterval(() => {
             if (!this.isConnected()) {

--- a/src/factories/poloniexFactories.ts
+++ b/src/factories/poloniexFactories.ts
@@ -48,7 +48,7 @@ export function getSubscribedFeeds(options: any, products: string[]): Promise<Po
         const feed = getFeed<PoloniexFeed, ExchangeFeedConfig>(PoloniexFeed, config);
         if (!feed.isConnected()) {
             feed.reconnect(0);
-            feed.on('websocket-open', () => {
+            feed.once('websocket-open', () => {
                 subscribeToAll(products, feed, info);
             });
         } else {


### PR DESCRIPTION
```
27.11.2017 12:55:09 - debug: [poloniex] Sending message to WS server message=.
27.11.2017 12:55:19 - error: [poloniex] No heartbeat has been received from wss://api2.poloniex.com  in 34358 ms. Assuming the connection is dead and reconnecting
27.11.2017 12:55:19 - debug: [poloniex] Reconnecting to wss://api2.poloniex.com  in 2.5 seconds...
27.11.2017 12:55:19 - debug: [poloniex] Closing existing socket prior to reconnecting to wss://api2.poloniex.com
27.11.2017 12:55:24 - debug: [poloniex] Connection to wss://api2.poloniex.com  has been established.
27.11.2017 12:55:24 - debug: [poloniex] Sending message to WS server command=subscribe, channel=24
27.11.2017 12:55:24 - debug: [poloniex] Sending message to WS server command=subscribe, channel=121
27.11.2017 12:55:24 - debug: [poloniex] Sending message to WS server command=subscribe, channel=122
27.11.2017 12:55:24 - debug: [poloniex] Sending message to WS server command=subscribe, channel=123
27.11.2017 12:55:24 - debug: [poloniex] Sending message to WS server command=subscribe, channel=148
27.11.2017 12:55:24 - debug: [poloniex] Sending message to WS server command=subscribe, channel=149
27.11.2017 12:55:24 - debug: [poloniex] Sending message to WS server command=subscribe, channel=180
27.11.2017 12:55:24 - debug: [poloniex] Sending message to WS server command=subscribe, channel=1002
27.11.2017 12:55:24 - debug: [poloniex] Sending message to WS server command=unsubscribe, channel=1002
27.11.2017 12:55:24 - debug: [poloniex] Sending message to WS server command=unsubscribe, channel=24
27.11.2017 12:55:24 - debug: [poloniex] Sending message to WS server command=unsubscribe, channel=121
27.11.2017 12:55:24 - debug: [poloniex] Sending message to WS server command=unsubscribe, channel=122
27.11.2017 12:55:24 - debug: [poloniex] Sending message to WS server command=unsubscribe, channel=123
27.11.2017 12:55:24 - debug: [poloniex] Sending message to WS server command=unsubscribe, channel=148
27.11.2017 12:55:24 - debug: [poloniex] Sending message to WS server command=unsubscribe, channel=149
27.11.2017 12:55:24 - debug: [poloniex] Sending message to WS server command=unsubscribe, channel=180
27.11.2017 12:55:34 - debug: [poloniex] Sending message to WS server message=.
27.11.2017 12:55:38 - debug: [poloniex] Sending message to WS server message=.
27.11.2017 12:55:43 - debug: [poloniex] Unsubscribed from DASH-BTC
27.11.2017 12:55:43 - debug: [poloniex] Unsubscribed from BTC-USDT
27.11.2017 12:55:43 - debug: [poloniex] Unsubscribed from DASH-USDT
27.11.2017 12:55:43 - debug: [poloniex] Unsubscribed from LTC-USDT
27.11.2017 12:55:43 - debug: [poloniex] Unsubscribed from ETH-BTC
27.11.2017 12:55:43 - debug: [poloniex] Unsubscribed from ETH-USDT
27.11.2017 12:55:43 - debug: [poloniex] Unsubscribed from ZEC-USDT
27.11.2017 12:55:43 - debug: [poloniex] Sending message to WS server command=subscribe, channel=24
27.11.2017 12:55:43 - debug: [poloniex] Sending message to WS server command=subscribe, channel=121
27.11.2017 12:55:43 - debug: [poloniex] Sending message to WS server command=subscribe, channel=122
27.11.2017 12:55:43 - debug: [poloniex] Sending message to WS server command=subscribe, channel=123
27.11.2017 12:55:43 - debug: [poloniex] Sending message to WS server command=subscribe, channel=148
27.11.2017 12:55:43 - debug: [poloniex] Sending message to WS server command=subscribe, channel=149
27.11.2017 12:55:43 - debug: [poloniex] Sending message to WS server command=subscribe, channel=180
27.11.2017 12:55:53 - debug: [poloniex] Sending message to WS server message=.

```
As you can see there is no reconnection to the channel ticker 1002.