### PR TITLE
Refactor CCXT Exchange

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/ws": "0.0.37",
     "bignumber.js": "4.0.2",
     "bintrees": "1.0.1",
-    "ccxt": "1.10.641",
+    "ccxt": "1.10.694",
     "commander": "2.9.0",
     "crypto": "0.0.3",
     "gdax": "https://github.com/coinbase/gdax-node.git#32360ad73517f168054585a1b0fd6ae3d7e12a77",

--- a/src/core/ExchangeRateFilter.ts
+++ b/src/core/ExchangeRateFilter.ts
@@ -31,7 +31,7 @@ const ARRAY_FIELDS = ['bids', 'asks'];
  * Implements a stream filter that applies an exchange rate to a stream of GDAX messages.
  *
  *
- * If the FXService has any problems and enters an ErrorState, the  filter will continue to convert prices, but you
+ * If the FXService has any problems and enters an ErrorState, the filter will continue to convert prices, but you
  * can watch for FXRateMayBeInvalid events and respond accordingly
  */
 export class ExchangeRateFilter extends AbstractMessageTransform {

--- a/yarn.lock
+++ b/yarn.lock
@@ -435,9 +435,9 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
-ccxt@1.10.641:
-  version "1.10.641"
-  resolved "https://registry.yarnpkg.com/ccxt/-/ccxt-1.10.641.tgz#ad6d104be952b48526219baed633876d1423244d"
+ccxt@1.10.694:
+  version "1.10.694"
+  resolved "https://registry.yarnpkg.com/ccxt/-/ccxt-1.10.694.tgz#32ba9b5fdb8876b107526fdd8af1d48135f72bfd"
   dependencies:
     crypto-js "3.1.9-1"
     fetch-ponyfill "^4.1.0"


### PR DESCRIPTION
 * Wherever possible, cleaned up code and refactored implementations to more efficient versions.
   * Converted some for loops into `Object.entries` + `.map()` versions
   * Optimized error handling within promises.
   * Converted all Promise `.then()`ing to async/await.
 * Tweaked type signatures of functions that can possibly return `null` to indicate that fact.
 * Added a little bit of space between chunks of functions that were espeically cramped.
 * Bumped CCXT's version to latest release