### PR TITLE
Add candles endpoint to Public API

### DIFF
--- a/src/core/HFTFilter.ts
+++ b/src/core/HFTFilter.ts
@@ -12,7 +12,6 @@
  * License for the specific language governing permissions and limitations under the License.                              *
  ***************************************************************************************************************************/
 
-import { Logger } from '../utils/Logger';
 import { BaseOrderMessage, ChangedOrderMessage, isOrderMessage, isStreamMessage, NewOrderMessage, StreamMessage } from './Messages';
 import { RBTree } from 'bintrees';
 import { Duplex } from 'stream';
@@ -40,7 +39,6 @@ export interface HFTFilterStats {
  * re-order any messages that may have arrived out of order
  */
 export class HFTFilter extends Duplex {
-    private logger: Logger;
     private messages: RBTree<StreamMessage>;
     private messagesById: { [id: string]: BaseOrderMessage };
     private skippedMessages: number = 0;
@@ -49,7 +47,6 @@ export class HFTFilter extends Duplex {
 
     constructor(config: HFTFilterConfig) {
         super({ readableObjectMode: true, writableObjectMode: true });
-        this.logger = config.logger;
         this.targetQueueLength = config.targetQueueLength;
         this.clearQueue();
     }

--- a/src/core/MessageQueue.ts
+++ b/src/core/MessageQueue.ts
@@ -74,7 +74,6 @@ export class MessageQueue extends Duplex {
     private targetQueueLength: number;
     private lastSequence: number;
     private productId: string;
-    private messageListener: (type: string, data: any) => void;
     private waitForSnapshot: boolean;
 
     constructor(options: MessageQueueConfig) {
@@ -83,7 +82,6 @@ export class MessageQueue extends Duplex {
         this.productId = options.product;
         this.targetQueueLength = options.targetQueueLength || 10;
         this.lastSequence = -1000;
-        this.messageListener = undefined;
         this.waitForSnapshot = options.waitForSnapshot;
         this.clearQueue();
     }

--- a/src/exchanges/PublicExchangeAPI.ts
+++ b/src/exchanges/PublicExchangeAPI.ts
@@ -14,6 +14,7 @@
 
 import { BookBuilder } from '../lib/BookBuilder';
 import { BigJS } from '../lib/types';
+
 /**
  * A generic API interface that defines the standard REST features that any crypto exchange typically exposes
  *
@@ -46,7 +47,39 @@ export interface PublicExchangeAPI {
      * Load the ticker for the configured product from the REST API, Resolves with the latest ticker object, or else rejects with an HTTPError
      */
     loadTicker(gdaxProduct: string): Promise<Ticker>;
+
+    loadCandles(options: CandleRequestOptions): Promise<Candle[]>;
 }
+
+export interface Candle {
+    timestamp: Date;
+    open: BigJS;
+    close: BigJS;
+    high: BigJS;
+    low: BigJS;
+    volume: BigJS;
+}
+
+export interface CandleRequestOptions {
+    gdaxProduct: string;
+    interval: CandleInterval;
+    from: Date;
+    limit: number;
+    extra: any;
+}
+
+export type CandleInterval = '1m' | '3m' | '5m' | '10m' | '30m' | '1h' | '4h' | '12h' | '1d' | '3d' | '7d';
+export const IntervalInMS: { [interval: string]: number } = {'1m': 60 * 1000};
+IntervalInMS['3m'] = 3 * IntervalInMS['1m'];
+IntervalInMS['5m'] = 5 * IntervalInMS['1m'];
+IntervalInMS['10m'] = 10 * IntervalInMS['1m'];
+IntervalInMS['30m'] = 30 * IntervalInMS['1m'];
+IntervalInMS['1h'] = 60 * IntervalInMS['1m'];
+IntervalInMS['4h'] = 4 * IntervalInMS['1h'];
+IntervalInMS['12h'] = 12 * IntervalInMS['12h'];
+IntervalInMS['1d'] = 24 * IntervalInMS['24h'];
+IntervalInMS['3d'] = 3 * IntervalInMS['1d'];
+IntervalInMS['7d'] = 7 * IntervalInMS['1d'];
 
 /**
  * The interface for the book ticker. The standard GDAX api is employed. See (https://docs.gdax.com/#get-product-ticker)

--- a/src/exchanges/bitfinex/BitfinexExchangeAPI.ts
+++ b/src/exchanges/bitfinex/BitfinexExchangeAPI.ts
@@ -13,11 +13,18 @@
  ***************************************************************************************************************************/
 
 import { AuthenticatedExchangeAPI, Balances } from '../AuthenticatedExchangeAPI';
-import { Product, PublicExchangeAPI, Ticker } from '../PublicExchangeAPI';
+import { Candle, CandleRequestOptions, Product, PublicExchangeAPI, Ticker } from '../PublicExchangeAPI';
 import { AggregatedLevelWithOrders, BookBuilder } from '../../lib/BookBuilder';
 import * as BitfinexAuth from './BitfinexAuth';
 import {
-    BitfinexBalance, BitfinexOrderRequest, BitfinexOrderType, BitfinexResult, BitfinexSuccessfulOrderExecution, BitfinexTransferRequest, BitfinexWallet, isBFWallet
+    BitfinexBalance,
+    BitfinexOrderRequest,
+    BitfinexOrderType,
+    BitfinexResult,
+    BitfinexSuccessfulOrderExecution,
+    BitfinexTransferRequest,
+    BitfinexWallet,
+    isBFWallet
 } from './BitfinexAuth';
 import { Logger } from '../../utils/Logger';
 import { PRODUCT_MAP, REVERSE_CURRENCY_MAP, REVERSE_PRODUCT_MAP } from './BitfinexCommon';
@@ -26,9 +33,9 @@ import { ExchangeAuthConfig } from '../AuthConfig';
 import { Big, BigJS } from '../../lib/types';
 import { PlaceOrderMessage } from '../../core/Messages';
 import { LiveOrder } from '../../lib/Orderbook';
+import { extractResponse, GTTError, HTTPError } from '../../lib/errors';
 import request = require('superagent');
 import Response = request.Response;
-import { extractResponse, GTTError, HTTPError } from '../../lib/errors';
 
 const API_V1 = 'https://api.bitfinex.com/v1';
 
@@ -143,7 +150,7 @@ export class BitfinexExchangeAPI implements PublicExchangeAPI, AuthenticatedExch
     loadOrderbook(gdaxProduct: string): Promise<BookBuilder> {
         const product = BitfinexExchangeAPI.product(gdaxProduct);
         return request.get(`${API_V1}/book/${product}`)
-            .query({ grouped: 1 })
+            .query({grouped: 1})
             .accept('application/json')
             .then((res: Response) => {
                 if (res.status !== 200) {
@@ -269,6 +276,10 @@ export class BitfinexExchangeAPI implements PublicExchangeAPI, AuthenticatedExch
                 return balances;
             });
         });
+    }
+
+    loadCandles(options: CandleRequestOptions): Promise<Candle[]> {
+        return Promise.reject(new GTTError('Error loading products from Bitfinex'));
     }
 
     // -------------------------- Transfer methods -------------------------------------------------

--- a/src/lib/BigArray.ts
+++ b/src/lib/BigArray.ts
@@ -77,7 +77,7 @@ export default class BigArray {
         return this.values.length;
     }
 
-    sumTo(i: number) {
+    sumTo(i: number): BigJS {
         if (i < 0) {
             return ZERO;
         }
@@ -88,7 +88,7 @@ export default class BigArray {
         return i < n ? this.sumArray.values[i] : this.sumArray.values[n - 1];
     }
 
-    sum() {
+    sum(): BigJS {
         return this.sumTo(this.length - 1);
     }
 

--- a/src/lib/OrderbookUtils.ts
+++ b/src/lib/OrderbookUtils.ts
@@ -44,7 +44,7 @@ interface OrderbookCache {
  * Calculate stats for trades given an order book. The orderbook is immutable.
  */
 export default class OrderbookUtils {
-    static calcFees(fees: BigJS, totalCost: BigJS) {
+    static calcFees(fees: BigJS, totalCost: BigJS): { fees_total: BigJS; total_cost: BigJS } {
         const feesTotal = totalCost.times(fees);
         totalCost = totalCost.plus(feesTotal);
         return { fees_total: feesTotal, total_cost: totalCost };
@@ -250,7 +250,7 @@ export default class OrderbookUtils {
      * @param index {number}
      * @param isBuy {boolean}
      */
-    getCumulativeSize(index: number, isBuy: boolean) {
+    getCumulativeSize(index: number, isBuy: boolean): BigJS {
         const orderData = isBuy ? this.cache.asks : this.cache.bids;
         return orderData.sizes.sumTo(index);
     }
@@ -260,7 +260,7 @@ export default class OrderbookUtils {
      * @param index {number}
      * @param isBuy {boolean}
      */
-    getCumulativeCost(index: number, isBuy: boolean) {
+    getCumulativeCost(index: number, isBuy: boolean): BigJS {
         const orderData = isBuy ? this.cache.asks : this.cache.bids;
         return orderData.value.sumTo(index);
     }

--- a/src/lib/StreamCopier.ts
+++ b/src/lib/StreamCopier.ts
@@ -25,7 +25,6 @@ import { EventEmitter } from 'events';
  * trapdoor).
  */
 export class StreamCopier extends EventEmitter {
-    private feed: Readable;
     private outputs: StreamConnection[];
     private bufferStreams: PassThrough[];
     private numConnected: number;
@@ -40,7 +39,6 @@ export class StreamCopier extends EventEmitter {
      */
     constructor(feed: Readable, numOutputs: number, options?: any) {
         super();
-        this.feed = feed;
         this.outputs = [];
         this.bufferStreams = new Array(numOutputs);
         options = options || { objectMode: true };

--- a/src/samples/traderDemo.ts
+++ b/src/samples/traderDemo.ts
@@ -105,7 +105,6 @@ getSubscribedFeeds({ auth: auth, logger: logger }, [product]).then((feed: GDAXFe
     };
     const trader = new Trader(traderConfig);
     const orders = new StaticCommandSet(messages, false);
-    let cancellations = 0;
     // We use a limiter to play each order once every 2 seconds.
     const limiter = new Limiter(1, 500);
     // We'll play the orders through the limiter, so connect them up
@@ -132,7 +131,6 @@ getSubscribedFeeds({ auth: auth, logger: logger }, [product]).then((feed: GDAXFe
         };
         orders.messages.push(cancel);
         orders.sendOne();
-        cancellations++;
         if (msg.price.toString() === '1.4') {
             orders.end();
         }

--- a/src/server/DataFeed.ts
+++ b/src/server/DataFeed.ts
@@ -35,20 +35,18 @@ export const serverOptions: IServerOptions = {
     clientTracking: true
 };
 
-let dataFeed: DataFeed = null;
-
 export function dataFeedFactory(): Server {
     if (server === undefined) {
         server = new Server(serverOptions);
-        logger.log('info', 'Websocket server listening on port ' + server.options.port);
+        logger.log('info', `Websocket server listening on port ${server.options.port}`);
         server.on('connection', (socket: WebSocket) => {
-            dataFeed = new DataFeed(socket);
+            logger.log('debug', 'Websocket connection made to ' + server.options.host);
         });
     }
     return server;
 }
 
-interface ExchangeConnection {
+export interface ExchangeConnection {
     feed: ExchangeFeed;
     products: string[];
     tickerTriggers: { [product: string]: Trigger<TickerMessage> };
@@ -66,7 +64,7 @@ function createLiveBook(feed: ExchangeFeed, product: string): LiveOrderbook {
     return book;
 }
 
-class DataFeed {
+export class DataFeed {
     private socket: WebSocket;
     private exchanges: { [exchange: string]: ExchangeConnection } = {};
 
@@ -246,7 +244,7 @@ class DataFeed {
         if (!book) {
             return;
         }
-        const ticker: TickerMessage = { type: 'ticker', time: new Date(), ...book.ticker };
+        const ticker: TickerMessage = {type: 'ticker', time: new Date(), ...book.ticker};
         this.send(wrapMessage(ticker, cmd));
     }
 


### PR DESCRIPTION
- Add `loadCandles` endpoint to PublicAPI and implement for GDAX and CCXT
- Fix some compiler errors introduced by TypeScript 2.7