### PR TITLE
All ExchangeFeed subclasses emit 'snapshot' asynchronously.

### DIFF
--- a/src/exchanges/bitfinex/BitfinexFeed.ts
+++ b/src/exchanges/bitfinex/BitfinexFeed.ts
@@ -273,7 +273,11 @@ export class BitfinexFeed extends ExchangeFeed {
                     })
                 };
                 if (self.standardMessages) {
-                    self.push(self.mapSnapshot(snapshot));
+                    const s = self.mapSnapshot(snapshot);
+                    process.nextTick(() => {
+                        self.emit('snapshot', s.productId);
+                    });
+                    self.push(s);
                 } else {
                     self.push(snapshot);
                 }

--- a/src/exchanges/bitmex/BitmexMarketFeed.ts
+++ b/src/exchanges/bitmex/BitmexMarketFeed.ts
@@ -150,6 +150,9 @@ export class BitmexMarketFeed extends ExchangeFeed {
         };
 
         this.push(snapshotMsg);
+        process.nextTick(() => {
+            this.emit('snapshot', snapshotMsg.productId);
+        });
     }
 
     private handleOrderbookUpdate(updates: OrderbookUpdateMessage) {

--- a/src/exchanges/bittrex/BittrexFeed.ts
+++ b/src/exchanges/bittrex/BittrexFeed.ts
@@ -75,6 +75,9 @@ export class BittrexFeed extends ExchangeFeed {
                         }
                         const snapshot: SnapshotMessage = this.processSnapshot(product, data);
                         this.push(snapshot);
+                        process.nextTick(() => {
+                            this.emit('snapshot', snapshot.productId);
+                        });
                         return resolve(true);
                     });
                 });

--- a/src/exchanges/gdax/GDAXFeed.ts
+++ b/src/exchanges/gdax/GDAXFeed.ts
@@ -365,7 +365,9 @@ export class GDAXFeed extends ExchangeFeed {
 
     private processSnapshot(snapshot: SnapshotMessage) {
         this.push(snapshot);
-        this.emit('snapshot');
+        process.nextTick(() => {
+            this.emit('snapshot', snapshot.productId);
+        });
     }
 
     /**

--- a/src/exchanges/gemini/GeminiMarketFeed.ts
+++ b/src/exchanges/gemini/GeminiMarketFeed.ts
@@ -60,7 +60,11 @@ export class GeminiMarketFeed extends ExchangeFeed {
     private processUpdate(update: GI.GeminiUpdateMessage) {
         if (update.socket_sequence === 0) {
             // Process the first message with the orderbook state
-            this.push(this.createSnapshotMessage(update));
+            const snapshot = this.createSnapshotMessage(update);
+            this.push(snapshot);
+            process.nextTick(() => {
+                this.emit('snapshot', snapshot.productId);
+            });
         } else {
             update.events.forEach((event) => {
                 let message: StreamMessage;

--- a/src/exchanges/poloniex/PoloniexFeed.ts
+++ b/src/exchanges/poloniex/PoloniexFeed.ts
@@ -306,6 +306,9 @@ export class PoloniexFeed extends ExchangeFeed {
                     channelInfo.sequence = sequence;
                     const snapshot: SnapshotMessage = self.createSnapshotMessage(product, sequence, update[1]);
                     self.push(snapshot);
+                    process.nextTick(() => {
+                        self.emit('snapshot', snapshot.productId);
+                    });
                     return;
                 }
                 if (type === 'o') {


### PR DESCRIPTION
Use process.nextTick() instead of setImmediate() so that the snapshot
message can be handled by any listeners before any follow up IO which
may cause a state change.