### PR TITLE
Handle GDAX ticker messages without a time property.

### DIFF
--- a/src/exchanges/gdax/GDAXFeed.ts
+++ b/src/exchanges/gdax/GDAXFeed.ts
@@ -307,7 +307,7 @@ export class GDAXFeed extends ExchangeFeed {
     private mapTicker(ticker: GDAXTickerMessage): StreamMessage {
         return {
             type: 'ticker',
-            time: new Date(ticker.time),
+            time: ticker.time ? new Date(ticker.time) : new Date(),
             productId: ticker.product_id,
             sequence: ticker.sequence,
             price: Big(ticker.price),


### PR DESCRIPTION
For example, the raw string from GDAX:

{"type":"ticker","sequence":13096274,"product_id":"BTC-USD","price":"11141.01000000","open_24h":"11468.00000000","volume_24h":"45430.96617205","low_24h":"8130.00000000","high_24h":"11478.01000000","volume_30d":"549612.32884134","best_bid":"11141","best_ask":"11141.13"}