### PR TITLE
Make ExchangeFeedConfig's and GDAXFeedConfig's auth property optional.

### DIFF
--- a/src/exchanges/ExchangeFeed.ts
+++ b/src/exchanges/ExchangeFeed.ts
@@ -23,7 +23,7 @@ import { sanitizeMessage } from '../core/Messages';
 export class ExchangeFeedConfig {
     wsUrl: string;
     logger: Logger;
-    auth: ExchangeAuthConfig;
+    auth?: ExchangeAuthConfig;
 }
 
 // hooks for replacing libraries if desired

--- a/src/exchanges/gdax/GDAXFeed.ts
+++ b/src/exchanges/gdax/GDAXFeed.ts
@@ -64,7 +64,7 @@ export const GDAX_WS_FEED = 'wss://ws-feed.gdax.com';
  *   - `user` - If you provided auth credentials, private messages will also be sent
  */
 export interface GDAXFeedConfig extends ExchangeFeedConfig {
-    auth: GDAXAuthConfig;
+    auth?: GDAXAuthConfig;
     wsUrl: string;
     channels?: string[]; // If supplied, the channels to subscribe to. This feature may be deprecated in a future release
     apiUrl: string;

--- a/tutorials/t005_alertTrader.ts
+++ b/tutorials/t005_alertTrader.ts
@@ -33,7 +33,7 @@ const spread = Big('0.15');
 
 const options: GDAXFeedConfig = {
     logger: logger,
-    auth: { key: null, secret: null, passphrase: null }, // use public feed
+    auth: undefined, // use public feed
     channels: ['ticker'],
     wsUrl: GDAX_WS_FEED,
     apiUrl: GDAX_API_URL


### PR DESCRIPTION
This allows having a single feed config with authorization and if one
wants a feed config that doesn't have authorization, one can do:

  const authConfig: ExchangeFeedConfig = { ...... };
  const nonAuthConfig: ExchangeFeedConfig = {...authConfig, auth: undefined};

This also matches GDAXConfig's auth property which is optional.