### PR TITLE
AbstractMessageTransform#transformMessage(): improve return type.

### DIFF
--- a/src/core/ProductFilter.ts
+++ b/src/core/ProductFilter.ts
@@ -13,6 +13,7 @@
  ***************************************************************************************************************************/
 
 import { AbstractMessageTransform, MessageTransformConfig } from '../lib/AbstractMessageTransform';
+import { StreamMessage } from '../core/Messages';
 
 export interface ProductFilterConfig extends MessageTransformConfig {
     productId: string;
@@ -29,8 +30,8 @@ export class ProductFilter extends AbstractMessageTransform {
         this.productId = config.productId;
     }
 
-    transformMessage(msg: any): any {
-        if (!msg || !msg.productId || msg.productId !== this.productId) {
+    transformMessage(msg: StreamMessage): StreamMessage {
+        if (!msg || !(msg as any).productId || (msg as any).productId !== this.productId) {
             return null;
         }
         return msg;

--- a/src/lib/AbstractMessageTransform.ts
+++ b/src/lib/AbstractMessageTransform.ts
@@ -46,7 +46,7 @@ export abstract class AbstractMessageTransform extends stream.Transform {
 
     _transform(chunk: any, encoding: string, callback: (err: Error, chunk?: any) => void) {
         if (typeof chunk === 'object' && isStreamMessage(chunk)) {
-            const msg: StreamMessage = chunk as StreamMessage;
+            const msg = chunk as StreamMessage;
             const transformed = this.transformMessage(msg);
             if (transformed) {
                 this.push(transformed);
@@ -56,5 +56,5 @@ export abstract class AbstractMessageTransform extends stream.Transform {
         return callback(null, chunk);
     }
 
-    abstract transformMessage(msg: StreamMessage): StreamMessage;
+    abstract transformMessage(msg: StreamMessage): null | StreamMessage;
 }


### PR DESCRIPTION
This lets other packages use AbstractMessageTransform and have it
override transformMessage() and return null to avoid a tsc warning:

  Type 'null' is not assignable to type 'StreamMessage'.