### PR TITLE
LiveOrderbook#processDoneMessage(): micro cleanup.

### DIFF
--- a/src/core/LiveOrderbook.ts
+++ b/src/core/LiveOrderbook.ts
@@ -292,8 +292,7 @@ export class LiveOrderbook extends Duplex implements Orderbook {
         // If we're using an order pool, then we only remove orders that we're aware of. GDAX, for example might
         // send a done message for a stop order that is cancelled (and was not previously known to us).
         // Also filled orders will already have been removed by the time a GDAX done order reaches here
-        const book: BookBuilder = this._book;
-        if (!book.hasOrder(msg.orderId)) {
+        if (!this._book.hasOrder(msg.orderId)) {
             return;
         }
         if (!(this._book.remove(msg.orderId))) {


### PR DESCRIPTION
No other code makes a copy of this._book, so don't do it here.