### PR TITLE
Messages.ts: documentation improvements.

### DIFF
--- a/src/core/Messages.ts
+++ b/src/core/Messages.ts
@@ -95,8 +95,6 @@ export function isOrderMessage(msg: any): boolean {
 
 /**
  * In order-level books, represents a new order.
- *
- * `orderType` is market, limit, stop
  */
 export interface NewOrderMessage extends BaseOrderMessage {
     type: 'newOrder';
@@ -164,6 +162,8 @@ export interface TickerMessage extends StreamMessage, Ticker {
 /**
  * A new order request message. Only the most common fields are specified here. Additional options can be specified
  * in the extra field, which can be handled by the target trade engine.
+ *
+ * `orderType` is limit, market, stop
  */
 export interface PlaceOrderMessage extends StreamMessage {
     productId: string;
@@ -184,6 +184,8 @@ export interface CancelOrderRequestMessage extends StreamMessage {
 
 /**
  * Emitted from a feed when one of my orders has been matched. (An authenticated feed is required)
+ *
+ * `orderType` is limit, market, stop
  */
 export interface TradeExecutedMessage extends StreamMessage {
     productId: string;
@@ -195,6 +197,10 @@ export interface TradeExecutedMessage extends StreamMessage {
     remainingSize: string;
 }
 
+/**
+ * Emitted when my order is finalized. (An authenticated feed is
+ * required).
+ */
 export interface TradeFinalizedMessage extends StreamMessage {
     productId: string;
     orderId: string;
@@ -204,6 +210,12 @@ export interface TradeFinalizedMessage extends StreamMessage {
     reason: string;
 }
 
+/**
+ * Emitted when my order is placed. (An authenticated feed is
+ * required).
+ *
+ * `orderType` is limit, market, stop
+ */
 export interface MyOrderPlacedMessage extends StreamMessage {
     productId: string;
     orderId: string;


### PR DESCRIPTION
Remove documentation on the orderType property which NewOrderMessage
doesn't have.

orderType only appears in PlaceOrderMessage, TradeExecutedMessage and
MyOrderPlacedMessage, so add it there.

Also add comments on TradeFinalizedMessage and MyOrderPlacedMessage.