### PR TITLE
Prevent future lint warnings about too long lines.

### DIFF
--- a/src/consoles/gdaxConsole.ts
+++ b/src/consoles/gdaxConsole.ts
@@ -22,7 +22,9 @@ import { Ticker } from '../exchanges/PublicExchangeAPI';
 import { Balances } from '../exchanges/AuthenticatedExchangeAPI';
 import { PlaceOrderMessage } from '../core/Messages';
 import { LiveOrder } from '../lib/Orderbook';
-import { AuthCallOptions, GDAXAuthConfig, GDAXConfig } from '../exchanges/gdax/GDAXInterfaces';
+import { AuthCallOptions,
+         GDAXAuthConfig,
+         GDAXConfig } from '../exchanges/gdax/GDAXInterfaces';
 import { TransferRequest, TransferResult } from '../exchanges/ExchangeTransferAPI';
 import { Big } from '../lib/types';
 

--- a/src/core/ExchangeRateFilter.ts
+++ b/src/core/ExchangeRateFilter.ts
@@ -12,7 +12,8 @@
  * License for the specific language governing permissions and limitations under the License.                              *
  ***************************************************************************************************************************/
 
-import { AbstractMessageTransform, MessageTransformConfig } from '../lib/AbstractMessageTransform';
+import { AbstractMessageTransform,
+         MessageTransformConfig } from '../lib/AbstractMessageTransform';
 import { StreamMessage } from './Messages';
 import { CurrencyPair, FXObject, pairAsString } from '../FXService/FXProvider';
 import { FXRates, FXService } from '../FXService/FXService';

--- a/src/core/HFTFilter.ts
+++ b/src/core/HFTFilter.ts
@@ -12,7 +12,12 @@
  * License for the specific language governing permissions and limitations under the License.                              *
  ***************************************************************************************************************************/
 
-import { BaseOrderMessage, ChangedOrderMessage, isOrderMessage, isStreamMessage, NewOrderMessage, StreamMessage } from './Messages';
+import { BaseOrderMessage,
+         ChangedOrderMessage,
+         isOrderMessage,
+         isStreamMessage,
+         NewOrderMessage,
+         StreamMessage } from './Messages';
 import { RBTree } from 'bintrees';
 import { Duplex } from 'stream';
 import { MessageTransformConfig } from '../lib/AbstractMessageTransform';

--- a/src/core/LiveOrderbook.ts
+++ b/src/core/LiveOrderbook.ts
@@ -13,8 +13,14 @@
  ***************************************************************************************************************************/
 
 import { Big, BigJS, Biglike, ZERO } from '../lib/types';
-import { CumulativePriceLevel, Level3Order, Orderbook, OrderbookState } from '../lib/Orderbook';
-import { AggregatedLevelFactory, AggregatedLevelWithOrders, BookBuilder, StartPoint } from '../lib/BookBuilder';
+import { CumulativePriceLevel,
+         Level3Order,
+         Orderbook,
+         OrderbookState } from '../lib/Orderbook';
+import { AggregatedLevelFactory,
+         AggregatedLevelWithOrders,
+         BookBuilder,
+         StartPoint } from '../lib/BookBuilder';
 import { Logger } from '../utils/Logger';
 import { Ticker } from '../exchanges/PublicExchangeAPI';
 import {

--- a/src/core/ProductFilter.ts
+++ b/src/core/ProductFilter.ts
@@ -12,7 +12,8 @@
  * License for the specific language governing permissions and limitations under the License.                              *
  ***************************************************************************************************************************/
 
-import { AbstractMessageTransform, MessageTransformConfig } from '../lib/AbstractMessageTransform';
+import { AbstractMessageTransform,
+         MessageTransformConfig } from '../lib/AbstractMessageTransform';
 
 export interface ProductFilterConfig extends MessageTransformConfig {
     productId: string;

--- a/src/core/Trader.ts
+++ b/src/core/Trader.ts
@@ -17,7 +17,13 @@ import { Logger } from '../utils/Logger';
 import { AuthenticatedExchangeAPI } from '../exchanges/AuthenticatedExchangeAPI';
 import { BookBuilder } from '../lib/BookBuilder';
 import { Level3Order, LiveOrder, OrderbookState } from '../lib/Orderbook';
-import { CancelOrderRequestMessage, isStreamMessage, MyOrderPlacedMessage, PlaceOrderMessage, StreamMessage, TradeExecutedMessage, TradeFinalizedMessage } from './Messages';
+import { CancelOrderRequestMessage,
+         isStreamMessage,
+         MyOrderPlacedMessage,
+         PlaceOrderMessage,
+         StreamMessage,
+         TradeExecutedMessage,
+         TradeFinalizedMessage } from './Messages';
 import { OrderbookDiff } from '../lib/OrderbookDiff';
 import { Big, BigJS } from '../lib/types';
 import { StreamError } from '../lib/errors';

--- a/src/factories/bitfinexFactories.ts
+++ b/src/factories/bitfinexFactories.ts
@@ -14,9 +14,11 @@
 
 import { BitfinexExchangeAPI } from '../exchanges/bitfinex/BitfinexExchangeAPI';
 import { Logger } from '../utils/Logger';
-import { BitfinexFeed, BitfinexFeedConfig } from '../exchanges/bitfinex/BitfinexFeed';
+import { BitfinexFeed,
+         BitfinexFeedConfig } from '../exchanges/bitfinex/BitfinexFeed';
 import { ExchangeAuthConfig } from '../exchanges/AuthConfig';
-import { BITFINEX_WS_FEED, PRODUCT_MAP } from '../exchanges/bitfinex/BitfinexCommon';
+import { BITFINEX_WS_FEED,
+         PRODUCT_MAP } from '../exchanges/bitfinex/BitfinexCommon';
 import { Product } from '../exchanges/PublicExchangeAPI';
 import { getFeed } from '../exchanges/ExchangeFeed';
 

--- a/src/factories/gdaxFactories.ts
+++ b/src/factories/gdaxFactories.ts
@@ -12,8 +12,11 @@
  * License for the specific language governing permissions and limitations under the License.                              *
  ***************************************************************************************************************************/
 
-import { GDAX_WS_FEED, GDAXFeed, GDAXFeedConfig } from '../exchanges/gdax/GDAXFeed';
-import { GDAX_API_URL, GDAXExchangeAPI } from '../exchanges/gdax/GDAXExchangeAPI';
+import { GDAX_WS_FEED,
+         GDAXFeed,
+         GDAXFeedConfig } from '../exchanges/gdax/GDAXFeed';
+import { GDAX_API_URL,
+         GDAXExchangeAPI } from '../exchanges/gdax/GDAXExchangeAPI';
 import { Product } from '../exchanges/PublicExchangeAPI';
 import { Logger } from '../utils/Logger';
 import { getFeed } from '../exchanges/ExchangeFeed';

--- a/src/factories/poloniexFactories.ts
+++ b/src/factories/poloniexFactories.ts
@@ -13,8 +13,12 @@
  ***************************************************************************************************************************/
 
 import { Logger } from '../utils/Logger';
-import { PoloniexFeed, PoloniexFeedConfig } from '../exchanges/poloniex/PoloniexFeed';
-import { gdaxToPolo, getAllProductInfo, POLONIEX_WS_FEED, PoloniexProducts } from '../exchanges/poloniex/PoloniexCommon';
+import { PoloniexFeed,
+         PoloniexFeedConfig } from '../exchanges/poloniex/PoloniexFeed';
+import { gdaxToPolo,
+         getAllProductInfo,
+         POLONIEX_WS_FEED,
+         PoloniexProducts } from '../exchanges/poloniex/PoloniexCommon';
 import { ExchangeFeedConfig, getFeed } from '../exchanges/ExchangeFeed';
 import { ExchangeAuthConfig } from '../exchanges/AuthConfig';
 import CCXTExchangeWrapper from '../exchanges/ccxt';

--- a/src/lib/BookBuilder.ts
+++ b/src/lib/BookBuilder.ts
@@ -12,7 +12,14 @@
  * License for the specific language governing permissions and limitations under the License.                              *
  ***************************************************************************************************************************/
 
-import { CumulativePriceLevel, Level3Order, Orderbook, OrderbookState, PriceComparable, PriceLevel, PriceLevelWithOrders, PriceTreeFactory } from './Orderbook';
+import { CumulativePriceLevel,
+         Level3Order,
+         Orderbook,
+         OrderbookState,
+         PriceComparable,
+         PriceLevel,
+         PriceLevelWithOrders,
+         PriceTreeFactory } from './Orderbook';
 import { Big, BigJS, Biglike, ZERO } from './types';
 import { RBTree } from 'bintrees';
 import { EventEmitter } from 'events';

--- a/src/lib/OrderbookDiff.ts
+++ b/src/lib/OrderbookDiff.ts
@@ -12,9 +12,16 @@
  * License for the specific language governing permissions and limitations under the License.                              *
  ***************************************************************************************************************************/
 
-import { CancelOrderRequestMessage, PlaceOrderMessage, StreamMessage } from '../core/Messages';
-import { Level3Order, OrderbookState, PriceLevel, PriceLevelWithOrders } from './Orderbook';
-import { AggregatedLevel, AggregatedLevelWithOrders, BookBuilder } from './BookBuilder';
+import { CancelOrderRequestMessage,
+         PlaceOrderMessage,
+         StreamMessage } from '../core/Messages';
+import { Level3Order,
+         OrderbookState,
+         PriceLevel,
+         PriceLevelWithOrders } from './Orderbook';
+import { AggregatedLevel,
+         AggregatedLevelWithOrders,
+         BookBuilder } from './BookBuilder';
 import { RBTree } from 'bintrees';
 import { BigJS, ZERO } from './types';
 

--- a/src/samples/exchangeAPIDemo.ts
+++ b/src/samples/exchangeAPIDemo.ts
@@ -16,13 +16,15 @@
  * This script demonstrates how to access Bitfinex's and GDAX trading APIs using the same set of standardized calls,
  * returning data in a consistent format
  */
-import { BitfinexConfig, BitfinexExchangeAPI } from '../exchanges/bitfinex/BitfinexExchangeAPI';
+import { BitfinexConfig,
+         BitfinexExchangeAPI } from '../exchanges/bitfinex/BitfinexExchangeAPI';
 import { ConsoleLoggerFactory, Logger } from '../utils/Logger';
 import { GDAXExchangeAPI } from '../exchanges/gdax/GDAXExchangeAPI';
 import { PublicExchangeAPI, Ticker } from '../exchanges/PublicExchangeAPI';
 import { BookBuilder } from '../lib/BookBuilder';
 import { printOrderbook, printTicker } from '../utils/printers';
-import { AuthenticatedExchangeAPI, Balances } from '../exchanges/AuthenticatedExchangeAPI';
+import { AuthenticatedExchangeAPI,
+         Balances } from '../exchanges/AuthenticatedExchangeAPI';
 import { LiveOrder } from '../lib/Orderbook';
 import { DefaultAPI } from '../factories/bittrexFactories';
 import { GDAXConfig } from '../exchanges/gdax/GDAXInterfaces';

--- a/src/samples/gdaxDemo.ts
+++ b/src/samples/gdaxDemo.ts
@@ -12,7 +12,8 @@
  * License for the specific language governing permissions and limitations under the License.                              *
  ***************************************************************************************************************************/
 
-import { AvailableBalance, Balances } from '../exchanges/AuthenticatedExchangeAPI';
+import { AvailableBalance,
+         Balances } from '../exchanges/AuthenticatedExchangeAPI';
 import { Big, BigJS } from '../lib/types';
 import { Ticker } from '../exchanges/PublicExchangeAPI';
 import { LiveOrder, Orderbook } from '../lib/Orderbook';

--- a/src/samples/liveOrderbookDemo.ts
+++ b/src/samples/liveOrderbookDemo.ts
@@ -16,7 +16,9 @@ import { ConsoleLoggerFactory } from '../utils/Logger';
 import { printTicker } from '../utils/printers';
 import { GDAXFeed } from '../exchanges/gdax/GDAXFeed';
 import { DefaultAPI, getSubscribedFeeds } from '../factories/gdaxFactories';
-import { LiveBookConfig, LiveOrderbook, SkippedMessageEvent } from '../core/LiveOrderbook';
+import { LiveBookConfig,
+         LiveOrderbook,
+         SkippedMessageEvent } from '../core/LiveOrderbook';
 import { Ticker } from '../exchanges/PublicExchangeAPI';
 import { TradeMessage } from '../core/Messages';
 import { OrderbookDiff } from '../lib/OrderbookDiff';

--- a/src/samples/traderDemo.ts
+++ b/src/samples/traderDemo.ts
@@ -18,7 +18,8 @@ import { GDAXFeed } from '../exchanges/gdax/GDAXFeed';
 import { Trader, TraderConfig } from '../core/Trader';
 import Limiter from '../core/RateLimiter';
 import {
-    CancelOrderRequestMessage, ErrorMessage,
+    CancelOrderRequestMessage,
+    ErrorMessage,
     PlaceOrderMessage,
     StreamMessage,
     TradeExecutedMessage,


### PR DESCRIPTION
For import lines longer than 80 characters, wrap them. This preempts a
`yarn lint` warning later on when introducing new imports.