### PR TITLE
.npmignore: fix `yarn pack` not putting all the files into build/src.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,7 +6,7 @@ node_modules/
 !types/
 docs/apiref
 
-src/
+/src/
 npm-shrinkwrap.json
 yarn.lock
 tsconfig.json


### PR DESCRIPTION
Without this the resulting compressed archive has only
build/src/index.js and no other files in it.