### PR TITLE
GDAXExchangeAPI#placeOrder: use AuthenticatedClient#placeOrder() dire…

### DIFF
--- a/src/exchanges/gdax/GDAXExchangeAPI.ts
+++ b/src/exchanges/gdax/GDAXExchangeAPI.ts
@@ -243,10 +243,7 @@ export class GDAXExchangeAPI implements PublicExchangeAPI, AuthenticatedExchange
                 return Promise.reject(new GTTError('Invalid Order type: ' + order.type));
         }
 
-        // TODO: use this.authClient.placeOrder() when gdax's
-        // index.d.ts adds it.
-        const promise = side === 'buy' ? this.authClient.buy(gdaxOrder) : this.authClient.sell(gdaxOrder);
-        return promise.then((result: OrderResult) => {
+        return this.authClient.placeOrder(gdaxOrder).then((result: OrderResult) => {
             // Check for error
             // TODO: Remove the first type assertion when https://github.com/coinbase/gdax-node/issues/269 is fixed.
             if ((result as any).status === 'rejected' || (result as any).message) {


### PR DESCRIPTION
…ctly.

This change is possible with the upgrade to gdax 0.6.0.