### PR TITLE
GDAX factories check for required env vars before building GDAXAuthCo…

### DIFF
--- a/src/factories/gdaxFactories.ts
+++ b/src/factories/gdaxFactories.ts
@@ -21,6 +21,19 @@ import { GDAXAuthConfig } from '../exchanges/gdax/GDAXInterfaces';
 
 let publicAPIInstance: GDAXExchangeAPI;
 
+function getAuthFromEnv(): null | GDAXAuthConfig {
+    const env = process.env;
+    if (env.GDAX_KEY && env.GDAX_SECRET && env.GDAX_PASSPHRASE) {
+        return {
+            key: process.env.GDAX_KEY,
+            secret: process.env.GDAX_SECRET,
+            passphrase: process.env.GDAX_PASSPHRASE
+        };
+    } else {
+        return null;
+    }
+}
+
 /**
  * A convenience function that returns a GDAXExchangeAPI instance for accessing REST methods conveniently. If API
  * key details are found in the GDAX_KEY etc. envars, they will be used
@@ -30,11 +43,7 @@ export function DefaultAPI(logger: Logger): GDAXExchangeAPI {
         publicAPIInstance = new GDAXExchangeAPI({
             logger: logger,
             apiUrl: GDAX_API_URL,
-            auth: {
-                key: process.env.GDAX_KEY,
-                secret: process.env.GDAX_SECRET,
-                passphrase: process.env.GDAX_PASSPHRASE
-            }
+            auth: getAuthFromEnv()
         });
     }
     return publicAPIInstance;
@@ -78,11 +87,7 @@ export function getSubscribedFeeds(options: any, products: string[]): Promise<GD
  * It is assumed that your API keys are stored in the GDAX_KEY, GDAX_SECRET and GDAX_PASSPHRASE envars
  */
 export function FeedFactory(logger: Logger, productIDs?: string[], auth?: GDAXAuthConfig): Promise<GDAXFeed> {
-    auth = auth || {
-        key: process.env.GDAX_KEY,
-        secret: process.env.GDAX_SECRET,
-        passphrase: process.env.GDAX_PASSPHRASE
-    };
+    auth = auth || getAuthFromEnv();
     // Use the GDAX API to get, and subscribe to all the endpoints
     let productPromise: Promise<string[]>;
     if (productIDs) {


### PR DESCRIPTION
…nfig.

This is a partial workaround to a problem where GDAXExchangeAPI will
construct a AuthenticatedClient if the constructor is given a defined
GDAXAuthConfig, however the constructor doesn't check that the key,
secret and passphrase properties are defined, so AuthenticatedClient
will throw an error.

So only a construct a GDAXAuthConfig if the required environmental
variables are all set.