### PR TITLE
GDAXExchangeAPI#checkAuth: two minor improvements.

### DIFF
--- a/src/exchanges/gdax/GDAXExchangeAPI.ts
+++ b/src/exchanges/gdax/GDAXExchangeAPI.ts
@@ -376,9 +376,9 @@ export class GDAXExchangeAPI implements PublicExchangeAPI, AuthenticatedExchange
         });
     }
 
-    checkAuth(): Promise<GDAXAuthConfig> {
+    checkAuth(): Promise<void> {
         return new Promise((resolve, reject) => {
-            if (this.auth === null) {
+            if (!this.auth) {
                 return reject(new GTTError('You cannot make authenticated requests if a GDAXAuthConfig object was not provided to the GDAXExchangeAPI constructor'));
             }
             if (!(this.auth.key && this.auth.secret && this.auth.passphrase)) {


### PR DESCRIPTION
- Fix the declared return type to match that nothing is returned.
- Don't assume that this.auth is set to null.