### PR TITLE
Upgrade @types/node to 7.0.58.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/commander": "2.3.31",
     "@types/crypto-js": "3.1.32",
     "@types/nock": "8.2.0",
-    "@types/node": "6.0.51",
+    "@types/node": "7.0.58",
     "@types/query-string": "3.0.30",
     "@types/simple-mock": "0.0.27",
     "@types/superagent": "2.0.35",

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,9 +56,9 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@6.0.51":
-  version "6.0.51"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.51.tgz#84cbf25111516ec9304d0b61469dc0fa9d12ba32"
+"@types/node@*", "@types/node@7.0.58":
+  version "7.0.58"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.58.tgz#ae852120137f40a29731a559e48003bd2d5d19f7"
 
 "@types/query-string@3.0.30":
   version "3.0.30"


### PR DESCRIPTION
The minimum required version of NodeJS is 7.6 so update @types/node to match.

Run `yarn upgrade -E @types/node@7.0.58` followed by manual editting
of yarn.lock to remove 6.0.51 which was being used for @types/node@*.