### PR TITLE
GDAXExchangeAPI#loadAllOrders: make product argument optional.

### DIFF
--- a/src/exchanges/AuthenticatedExchangeAPI.ts
+++ b/src/exchanges/AuthenticatedExchangeAPI.ts
@@ -46,10 +46,10 @@ export interface AuthenticatedExchangeAPI {
     loadOrder(id: string): Promise<LiveOrder>;
 
     /**
-     * Loads all currently active orders placed by the user (i.e. not the full orderbook). If product is null, load
+     * Loads all currently active orders placed by the user (i.e. not the full orderbook). If product is undefined, load
      * all orders from all books
      */
-    loadAllOrders(gdaxProduct: string): Promise<LiveOrder[]>;
+    loadAllOrders(gdaxProduct?: string): Promise<LiveOrder[]>;
 
     /**
      * Return the balances for all the accounts the user has associated with the current authentication credentials

--- a/src/exchanges/bitfinex/BitfinexExchangeAPI.ts
+++ b/src/exchanges/bitfinex/BitfinexExchangeAPI.ts
@@ -245,7 +245,7 @@ export class BitfinexExchangeAPI implements PublicExchangeAPI, AuthenticatedExch
         });
     }
 
-    loadAllOrders(): Promise<LiveOrder[]> {
+    loadAllOrders(gdaxProduct?: string): Promise<LiveOrder[]> {
         return this.checkAuth().then((auth: ExchangeAuthConfig) => {
             return BitfinexAuth.activeOrders(auth).then((results: BitfinexSuccessfulOrderExecution[]) => {
                 if (this.logger) {

--- a/src/exchanges/ccxt/index.ts
+++ b/src/exchanges/ccxt/index.ts
@@ -305,7 +305,7 @@ export default class CCXTExchangeWrapper implements PublicExchangeAPI, Authentic
         throw new Error('Not implemented yet');
     }
 
-    loadAllOrders(gdaxProduct: string): Promise<LiveOrder[]> {
+    loadAllOrders(gdaxProduct?: string): Promise<LiveOrder[]> {
         throw new Error('Not implemented yet');
     }
 

--- a/src/exchanges/gdax/GDAXExchangeAPI.ts
+++ b/src/exchanges/gdax/GDAXExchangeAPI.ts
@@ -286,10 +286,10 @@ export class GDAXExchangeAPI implements PublicExchangeAPI, AuthenticatedExchange
         });
     }
 
-    loadAllOrders(product: string): Promise<LiveOrder[]> {
+    loadAllOrders(product?: string): Promise<LiveOrder[]> {
         const self = this;
         let allOrders: LiveOrder[] = [];
-        const loop: (after: string) => Promise<LiveOrder[]> = (after: string) => {
+        const loop: (after?: string) => Promise<LiveOrder[]> = (after?: string) => {
             return self.loadNextOrders(product, after).then((result) => {
                 const liveOrders: LiveOrder[] = result.orders.map(GDAXOrderInfoToOrder);
                 allOrders = allOrders.concat(liveOrders);
@@ -300,7 +300,7 @@ export class GDAXExchangeAPI implements PublicExchangeAPI, AuthenticatedExchange
                 }
             });
         };
-        return loop(null);
+        return loop();
     }
 
     loadBalances(): Promise<Balances> {
@@ -503,7 +503,7 @@ export class GDAXExchangeAPI implements PublicExchangeAPI, AuthenticatedExchange
         return book;
     }
 
-    private loadNextOrders(product: string, after: string): Promise<OrderPage> {
+    private loadNextOrders(product?: string, after?: string): Promise<OrderPage> {
         const qs: any = {
             status: ['open', 'pending', 'active']
         };


### PR DESCRIPTION
This lets programs that import gdax-trading-toolkit compile with
strict mode and pass in no product.