### PR TITLE
Trader.placeOrder should emit `Trader.order-placed`

### DIFF
--- a/src/core/Trader.ts
+++ b/src/core/Trader.ts
@@ -130,6 +130,7 @@ export class Trader extends Writable {
             } else {
                 this.unfilledMarketOrders.add(order.id);
             }
+            this.emitMessageAsync('Trader.order-placed', order);
             return order;
         }).catch((err: StreamError) => {
             // Errors can fail if they're too precise, too small, or the API is down


### PR DESCRIPTION
When a successful order has been placed with the `Trader` via `placeOrder` method it should emit 'Trader.order-placed' message for our event listeners.