### PR TITLE
Logger fix for #237

### DIFF
--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -20,7 +20,7 @@ export interface Logger {
     error(err: Error): void;
 }
 
-export function ConsoleLoggerFactory(options?: winston.ConsoleTransportOptions): Logger {
+export function ConsoleLoggerFactory(options?: winston.LoggerOptions): Logger {
     const consoleOptions: winston.ConsoleTransportOptions = {
         colorize: 'all',
         json: false,


### PR DESCRIPTION
@sfkiwi figured out this fix after a recent winston logger update broke the functionality to attach transports and logging to files (hopefully you don't mind me submitting this). This returns full functionality and I have been using/testing it for over a month now with no issues.

Fix source: https://github.com/sfkiwi/gdax-tt/commit/a75c6fc7cdeb2e1fd4542f210e9011e8732731cf
Original Issue: #237