### PR TITLE
ExchangeRatesAPIProvider.ts FX provider

### DIFF
--- a/src/FXService/providers/ExchangeRatesAPIProvider.ts
+++ b/src/FXService/providers/ExchangeRatesAPIProvider.ts
@@ -1,0 +1,95 @@
+/**********************************************************************************************************************
+ * @license                                                                                                           *
+ * Copyright 2017 Coinbase, Inc.                                                                                      *
+ *                                                                                                                    *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     *
+ * with the License. You may obtain a copy of the License at                                                          *
+ *                                                                                                                    *
+ * http://www.apache.org/licenses/LICENSE-2.0                                                                         *
+ *                                                                                                                    *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on*
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the                 *
+ * License for the specific language governing permissions and limitations under the License.                         *
+ **********************************************************************************************************************/
+
+import request = require('superagent');
+import { FXProvider, CurrencyPair, FXObject, pairAsString } from '../FXProvider';
+import Response = request.Response;
+import { Big } from '../../lib/types';
+
+export default class ExchangeRatesAPIProvider extends FXProvider {
+  // Global list of currenices, populated on initial calls 
+  // to supportsPair; maintained for the purposes of memoization
+  private static SUPPORTED_CURRENCIES: string[] = [];
+
+  get name(): string {
+    return 'Exchange Rates API (https://exchangeratesapi.io/)';
+  }
+
+  supportsPair(pair: CurrencyPair): Promise<boolean> {
+    if (ExchangeRatesAPIProvider.SUPPORTED_CURRENCIES.length > 0) {
+      return Promise.resolve(this.isSupportedPair(pair));
+    }
+
+    return request('https://api.exchangeratesapi.io/latest')
+      .accept('application/json')
+      .query({ format: 'json' })
+      .then<boolean>((response: Response) => {
+        if (
+          response.status !== 200 ||
+          !response.body ||
+          !response.body.base ||
+          !response.body.rates
+        ) {
+          const error = new Error(`Could not get list of supported currencies from ${this.name}`);
+          return Promise.reject(error);
+        }
+
+        const currencies: string[] = [];
+        currencies.push(response.body.base);
+        currencies.push(...Object.keys(response.body.rates));
+        ExchangeRatesAPIProvider.SUPPORTED_CURRENCIES = currencies;
+
+        return this.isSupportedPair(pair);
+      });
+  }
+
+  protected downloadCurrentRate(pair: CurrencyPair): Promise<FXObject> {
+    return request(`https://api.exchangeratesapi.io/latest?base=${pair.from}`)
+      .accept('application/json')
+      .query({ format: 'json' })
+      .then<FXObject>((response: Response) => {
+        if (
+          response.status !== 200 ||
+          !response.body ||
+          !response.body.rates
+        ) {
+          const error = new Error(`Could not download ${pairAsString(pair)} from ${this.name}`);
+          return Promise.reject(error);
+        }
+
+        const optionalRate = response.body.rates[pair.to];
+
+        if (optionalRate == null) {
+          const error = new Error(`No exchange rate found for ${pairAsString(pair)} from ${this.name}`);
+          return Promise.reject(error);
+        }
+
+        const fx: FXObject = {
+          time: new Date(response.body.date),
+          from: pair.from,
+          to: pair.to,
+          rate: Big(optionalRate)
+        };
+
+        return fx;
+     });
+  }
+
+  private isSupportedPair(pair: CurrencyPair): boolean {
+    return (
+      ExchangeRatesAPIProvider.SUPPORTED_CURRENCIES.indexOf(pair.from) >= 0 &&
+      ExchangeRatesAPIProvider.SUPPORTED_CURRENCIES.indexOf(pair.to) >= 0
+    );
+  }
+}


### PR DESCRIPTION
## Description
Sets up `FXProvider` accessing https://exchangeratesapi.io/.  My goal with this initial pull request is to establish this `FXProvider`, so I may remove references to Yahoo's `FXProvider` and replace them with this exchange rate service in later pull request(s).  Yahoo's service is no longer functional, and this replacement service is a decent default, as it doesn't require an API key and is fairly simple.  

NOTE: This is my first PR for this project, so I wanted to focus on something fairly simple to get into the flow of committing to this codebase, and also improve the runnable examples + current defaults for things such as `FXProvider`'s.  cc: @fb55 who seems to be the POC for this project according to #240.

## End-to-End Tests
```
const provider = new ExchangeRatesAPIProvider({});
provider.supportsPair({from: 'USD', to: 'NZD'})
  .then((isSupported) => console.log(`USD-NZD supported: ${isSupported}`));

provider.supportsPair({from: 'USD', to: 'ABC'})
  .then((isSupported) => console.log(`USD-ABC supported: ${isSupported}`));

provider.fetchCurrentRate({from: 'USD', to: 'EUR'})
  .then((fx) => console.log(`USD-EUR, ${fx.time}, ${fx.rate.toNumber()}`));

provider.fetchCurrentRate({from: 'USD', to: 'AUD'})
  .then((fx) => console.log(`USD-AUD, ${fx.time}, ${fx.rate.toNumber()}`));

provider.fetchCurrentRate({from: 'USD', to: 'USD'})
  .then((fx) => console.log(`USD-USD, ${fx.time}, ${fx.rate.toNumber()}`));

provider.fetchCurrentRate({from: 'USD', to: 'ABC'})
  .then((fx) => console.log(`USD-ABC, ${fx.time}, ${fx.rate.toNumber()}`))
  .catch((error) => console.log(error));
```
which output:
```
➜  gdax-tt git:(exchange-rates-api-fx-provider) ✗ ts-node src/FXService/providers/ExchangeRatesAPIProvider.ts
USD-USD, Tue Jan 29 2019 22:56:01 GMT-0800 (PST), 1
USD-ABC supported: false
{ Error: Currency pair USD-ABC or its inverse is not supported
    at supportsPair.then (....)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:160:7)
  provider: 'Exchange Rates API (https://exchangeratesapi.io/)' }
USD-NZD supported: true
USD-AUD, Mon Jan 28 2019 16:00:00 GMT-0800 (PST), 1.3967781474
USD-EUR, Mon Jan 28 2019 16:00:00 GMT-0800 (PST), 0.8755034145
```